### PR TITLE
Okay, I've refactored the code to centralize configuration in `config…

### DIFF
--- a/backtest_evolved_alphas.py
+++ b/backtest_evolved_alphas.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import argparse
+# import argparse # Removed
 import pickle
 import sys
 import textwrap # For printing program strings
@@ -30,21 +30,24 @@ except ImportError as e_bc:
 
 # Attempt to import INITIAL_STATE_VARS and evo_args from evolve_alphas (optional, for context)
 try:
-    from evolve_alphas import INITIAL_STATE_VARS as EVO_INITIAL_STATE_VARS, args as evo_args_global
+    from evolve_alphas import INITIAL_STATE_VARS as EVO_INITIAL_STATE_VARS #, args as evo_args_global # evo_args_global removed
 except ImportError:
     EVO_INITIAL_STATE_VARS = {"prev_s1_vec": "vector"} # Minimal fallback
-    evo_args_global = None
+    # evo_args_global = None # evo_args_global removed
+
+# Removed placeholder EvoConfig, will import from config.py
+from config import EvoConfig
 
 # Use INITIAL_STATE_VARS from evolve_alphas if available, otherwise a default.
 INITIAL_STATE_VARS_BT: Dict[str, str] = EVO_INITIAL_STATE_VARS if EVO_INITIAL_STATE_VARS else {
     "prev_s1_vec": "vector", # A common example
 }
 
-DEFAULT_PICKLE_FILE = "evolved_top_alphas.pkl"
-DEFAULT_DATA_DIR = "./data"
+DEFAULT_PICKLE_FILE = "evolved_top_alphas.pkl" # Kept as is
+DEFAULT_DATA_DIR = "./data" # Kept as is
 
-# Module-level global for parsed arguments of this script
-bt_args: argparse.Namespace | None = None 
+# Module-level global for parsed arguments of this script - REMOVED
+# bt_args: argparse.Namespace | None = None 
 
 def load_programs_from_pickle(n_to_load: int, pickle_filepath: str) \
         -> List[Tuple[AlphaProgram, float]]:
@@ -60,47 +63,33 @@ def load_programs_from_pickle(n_to_load: int, pickle_filepath: str) \
                  "Ensure the pickle file was created with compatible AlphaProgram versions.")
 
 
-def main() -> None:
-    global bt_args 
-    bt_ap = argparse.ArgumentParser(description="Back-test evolved cross-sectional alphas")
-    bt_ap.add_argument("--input", default=DEFAULT_PICKLE_FILE, help="Pickle file with evolved AlphaPrograms")
-    bt_ap.add_argument("--top", type=int, default=10, help="Number of top programs to backtest")
-    bt_ap.add_argument("--data", default=DEFAULT_DATA_DIR, help="Directory with *.csv OHLC data")
-    bt_ap.add_argument("--fee", type=float, default=1.0, help="Round-trip commission in bps")
-    bt_ap.add_argument("--hold", type=int, default=1, help="Holding period in bars")
-    bt_ap.add_argument("--scale", choices=["zscore", "rank", "sign"], default="zscore", help="Signal scaling method")
-    bt_ap.add_argument("--lag", type=int, default=1, help="Signal lag in bars for position taking")
-    bt_ap.add_argument("--outdir", default="evolved_bt_cs_results", help="Directory for output CSVs")
-    bt_ap.add_argument("--data_alignment_strategy", type=str, choices=['common_1200', 'specific_long_10k', 'full_overlap'], default='common_1200')
-    bt_ap.add_argument("--min_common_data_points", type=int, default=1200)
-    bt_ap.add_argument("--seed", type=int, default=None, help="RNG seed for backtest (if programs have stochastic elements)")
-    bt_ap.add_argument("--debug_prints", action="store_true", help="Enable debug prints in core logic")
-    bt_ap.add_argument("--annualization_factor_override", type=float, default=None, help="Override annualization factor (e.g., 252 for daily, 252*6 for 4H)")
+def main(cfg: EvoConfig) -> None: # Modified signature
+    # global bt_args # Removed
+    # Argument parsing logic removed, configuration now comes from cfg
 
-    bt_args = bt_ap.parse_args()
+    Path(cfg.output_dir).mkdir(parents=True, exist_ok=True)
 
-    Path(bt_args.outdir).mkdir(parents=True, exist_ok=True)
-
-    current_backtest_seed = bt_args.seed
-    if current_backtest_seed is None and evo_args_global and hasattr(evo_args_global, 'seed'):
-        current_backtest_seed = evo_args_global.seed
+    # Seed logic now relies on cfg.seed. 
+    # The caller of main (e.g. a script that instantiates EvoConfig) would be responsible
+    # for potentially incorporating evo_args_global.seed into cfg.seed if that's desired.
+    # current_backtest_seed = cfg.seed # Now directly use cfg.seed from the imported EvoConfig
     
-    if current_backtest_seed is not None:
-        print(f"Using seed {current_backtest_seed} for backtesting (affects NumPy/random if used by AlphaPrograms).")
-        random.seed(current_backtest_seed)
-        np.random.seed(current_backtest_seed)
+    if cfg.seed is not None:
+        print(f"Using seed {cfg.seed} for backtesting (affects NumPy/random if used by AlphaPrograms).")
+        random.seed(cfg.seed)
+        np.random.seed(cfg.seed)
 
-
-    print(f"Loading and aligning data for backtesting from: {bt_args.data}...")
+    # cfg.data_dir should be correctly populated by EvoConfig
+    print(f"Loading and aligning data for backtesting from: {cfg.data_dir}...") 
     aligned_dfs, common_index, stock_symbols = load_and_align_data_for_backtest(
-        bt_args.data, bt_args.data_alignment_strategy, bt_args.min_common_data_points
+        cfg.data_dir, cfg.max_lookback_data_option, cfg.min_common_points # Changed to EvoConfig field names
     )
     n_stocks_bt = len(stock_symbols)
     print(f"Backtesting on {n_stocks_bt} symbols over {len(common_index)} time steps.")
     if common_index is not None and len(common_index) > 0:
         print(f"Data spans from {common_index.min()} to {common_index.max()}.")
 
-    if bt_args.debug_prints:
+    if cfg.debug_prints:
         print("\n--- DEBUG: Verifying ret_fwd (Main Script) ---")
         for sym, df_debug in aligned_dfs.items():
             print(f"Symbol: {sym}, ret_fwd stats:\n{df_debug['ret_fwd'].describe()}")
@@ -108,7 +97,8 @@ def main() -> None:
                 print(f"WARNING: NaNs found in ret_fwd for {sym} after alignment.")
         print("--- END DEBUG: Verifying ret_fwd ---\n")
 
-    programs_to_backtest = load_programs_from_pickle(bt_args.top, bt_args.input)
+    # Use cfg.top_to_backtest and cfg.input_pickle_file from the imported EvoConfig
+    programs_to_backtest = load_programs_from_pickle(cfg.top_to_backtest, cfg.input_pickle_file)
     all_results = []
     
     for idx, (prog, original_metric) in enumerate(programs_to_backtest, 1):
@@ -122,15 +112,15 @@ def main() -> None:
             common_time_index=common_index,
             stock_symbols=stock_symbols,
             n_stocks=n_stocks_bt,
-            fee_bps=bt_args.fee,
-            lag=bt_args.lag,
-            hold=bt_args.hold,
-            scale_method=bt_args.scale,
-            initial_state_vars_config=INITIAL_STATE_VARS_BT,
+            fee_bps=cfg.fee, # Changed to EvoConfig field name
+            lag=cfg.eval_lag, # Changed to EvoConfig field name
+            hold=cfg.hold, # Changed to EvoConfig field name
+            scale_method=cfg.scale, # Changed to EvoConfig field name
+            initial_state_vars_config=INITIAL_STATE_VARS_BT, # Remains as is
             scalar_feature_names=SCALAR_FEATURE_NAMES,
             cross_sectional_feature_vector_names=CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
-            debug_prints=bt_args.debug_prints,
-            annualization_factor=bt_args.annualization_factor_override if bt_args.annualization_factor_override is not None else (252 * 6) # Default if not overridden
+            debug_prints=cfg.debug_prints, # Directly use from EvoConfig
+            annualization_factor=cfg.annualization_factor_override if cfg.annualization_factor_override is not None else (252 * 6) # Directly use from EvoConfig
         )
         
         metrics["AlphaID"] = f"Alpha_{idx:02d}"
@@ -151,7 +141,8 @@ def main() -> None:
         
         results_df = results_df.sort_values("Sharpe", ascending=False)
 
-        summary_csv_path = Path(bt_args.outdir) / f"backtest_summary_top{bt_args.top}.csv"
+        # Use cfg.output_dir and cfg.top_to_backtest from the imported EvoConfig
+        summary_csv_path = Path(cfg.output_dir) / f"backtest_summary_top{cfg.top_to_backtest}.csv"
         try:
             results_df.to_csv(summary_csv_path, index=False, float_format='%.4f')
             print(f"\nBacktest summary saved to: {summary_csv_path}")
@@ -161,5 +152,5 @@ def main() -> None:
         print("\n--- Backtest Summary ---")
         print(results_df.drop(columns=["Program", "Error"], errors='ignore').to_string(index=False))
 
-if __name__ == "__main__":
-    main()
+# Removed the if __name__ == "__main__": block as this script is not intended to be run directly in the pipeline.
+# The main function is called by run_pipeline.py with a fully populated EvoConfig object.

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 # config.py
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class EvoConfig:
@@ -44,3 +45,9 @@ class EvoConfig:
     top_to_backtest: int = 10 # Num best programs from evolution to backtest
     fee: float = 1.0          # Round-trip commission in bps for backtest
     hold: int = 1             # Holding period in bars for backtest
+
+    # New fields for pipeline/backtesting integration
+    input_pickle_file: Optional[str] = None
+    output_dir: Optional[str] = None # Specific output directory for backtest results
+    annualization_factor_override: Optional[float] = None
+    debug_prints: bool = False # For verbose debugging output in backtester


### PR DESCRIPTION
….py` for the pipeline. Here's what I did:

- I modified `backtest_evolved_alphas.py` so it now uses `EvoConfig` from `config.py`. This means I removed its local argument parsing and placeholder configuration.
- I also updated the attribute names in `backtest_evolved_alphas.py` to match the ones in `EvoConfig`.
- I added some new fields (`input_pickle_file`, `output_dir`, `annualization_factor_override`, `debug_prints`) to `EvoConfig` within `config.py`.
- Finally, I updated `run_pipeline.py` to pass the `EvoConfig` object directly to the main function of `backtest_evolved_alphas.py` and to correctly set the new attributes on the config object.