### PR TITLE
Add execution and random program tests

### DIFF
--- a/tests/test_op_execution.py
+++ b/tests/test_op_execution.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from alpha_framework import Op
+
+
+def test_scalar_to_vector_broadcast():
+    buf = {"vec": 2.0, "s": 3.0}
+    op = Op("out", "vec_mul_scalar", ("vec", "s"))
+    op.execute(buf, n_stocks=4)
+    assert np.allclose(buf["out"], np.full(4, 6.0))
+
+
+def test_vector_promoted_in_elementwise_scalar_slot():
+    buf = {"v": np.array([1.0, 2.0, 3.0]), "s": 1.0}
+    op = Op("out", "add", ("v", "s"))
+    op.execute(buf, n_stocks=3)
+    assert np.allclose(buf["out"], np.array([2.0, 3.0, 4.0]))
+
+
+def test_vector_size_adjustment():
+    buf = {"v": np.array([1.0, 2.0, 3.0, 4.0]), "s": 1.0}
+    op = Op("out", "vec_mul_scalar", ("v", "s"))
+    op.execute(buf, n_stocks=2)
+    assert np.allclose(buf["out"], np.array([1.0, 2.0]))
+
+
+def test_invalid_vector_type_raises():
+    buf = {"v": np.array([[1.0, 2.0], [3.0, 4.0]]), "s": 2.0}
+    op = Op("out", "vec_mul_scalar", ("v", "s"))
+    with pytest.raises(TypeError):
+        op.execute(buf, n_stocks=2)
+
+

--- a/tests/test_random_program.py
+++ b/tests/test_random_program.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from alpha_framework import AlphaProgram, FINAL_PREDICTION_VECTOR_NAME
+
+
+def test_random_program_final_op_vector():
+    feature_vars = AlphaProgram._get_default_feature_vars()
+    state_vars = {"dummy": "scalar"}
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        prog = AlphaProgram.random_program(feature_vars, state_vars, max_total_ops=8, rng=rng)
+        assert prog.predict_ops, "random_program should produce predict ops"
+        last_op = prog.predict_ops[-1]
+        assert last_op.out == FINAL_PREDICTION_VECTOR_NAME
+        after_setup = prog._trace_vars_for_block(prog.setup, {**feature_vars, **state_vars})
+        vars_after_predict = prog._trace_vars_for_block(prog.predict_ops, after_setup)
+        assert vars_after_predict[FINAL_PREDICTION_VECTOR_NAME] == "vector"


### PR DESCRIPTION
## Summary
- add tests for Op.execute behaviour with scalars and vectors
- check broadcasting, element-wise promotion and errors
- add tests ensuring AlphaProgram.random_program ends with a vector output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbdfe2e78832e9ed0023d1bc781af