### PR TITLE
Make every config option configurable from CLI

### DIFF
--- a/backtest_evolved_alphas.py
+++ b/backtest_evolved_alphas.py
@@ -55,6 +55,7 @@ def parse_args() -> tuple[BacktestConfig, argparse.Namespace]:
     p.add_argument("--data",              dest="data_dir",            default=argparse.SUPPRESS)
     p.add_argument("--fee",               type=float,                 default=argparse.SUPPRESS)
     p.add_argument("--hold",              type=int,                   default=argparse.SUPPRESS)
+    p.add_argument("--annualization_factor", type=float, default=argparse.SUPPRESS)
     p.add_argument("--scale",             choices=["zscore", "rank", "sign"],
                                                                   default=argparse.SUPPRESS)
     p.add_argument("--lag",               dest="eval_lag",            type=int,   default=argparse.SUPPRESS)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -38,6 +38,13 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig]:
     p.add_argument("--parsimony_penalty",  type=float, default=argparse.SUPPRESS)
     p.add_argument("--corr_penalty_w",     type=float, default=argparse.SUPPRESS)
     p.add_argument("--corr_cutoff",        type=float, default=argparse.SUPPRESS)
+    p.add_argument("--keep_dupes_in_hof", action="store_true",
+                   default=argparse.SUPPRESS)
+    p.add_argument("--xs_flat_guard",      type=float, default=argparse.SUPPRESS)
+    p.add_argument("--t_flat_guard",       type=float, default=argparse.SUPPRESS)
+    p.add_argument("--early_abort_bars",   type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--early_abort_xs",     type=float, default=argparse.SUPPRESS)
+    p.add_argument("--early_abort_t",      type=float, default=argparse.SUPPRESS)
     p.add_argument("--hof_size",           type=int,   default=argparse.SUPPRESS)
     p.add_argument("--scale",              choices=["zscore","rank","sign"],
                                                      default=argparse.SUPPRESS)
@@ -58,6 +65,7 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig]:
 
     p.add_argument("--fee",                            type=float, default=argparse.SUPPRESS)
     p.add_argument("--hold",                           type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--annualization_factor", type=float, default=argparse.SUPPRESS)
 
     ns = p.parse_args()
     d = vars(ns)
@@ -114,6 +122,7 @@ def main() -> None:
         "--top",   str(bt_cfg.top_to_backtest),
         "--fee",   str(bt_cfg.fee),
         "--hold",  str(bt_cfg.hold),
+        "--annualization_factor", str(bt_cfg.annualization_factor),
         "--scale", bt_cfg.scale,
         "--lag",   str(bt_cfg.eval_lag),
         "--data",  str(bt_cfg.data_dir),


### PR DESCRIPTION
## Summary
- expose missing evolutionary knobs in CLI: keep_dupes_in_hof, xs/t flat guards, early abort guards
- allow annualization_factor to be set from CLI
- pass annualization_factor through pipeline to backtests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684018f4df6c832e8e217b71e44e393d