### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Alpha Evolve
+
+Alpha Evolve is an experiment in evolving alpha factors for systematic trading.
+
+## Requirements
+
+- Python 3.12 or higher
+- See `requirements.txt` for Python package dependencies
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Alternatively run the helper script:
+
+```bash
+sh scripts/setup_env.sh
+```
+
+If you change dependencies using `uv add` or by editing `pyproject.toml`,
+update `requirements.txt` with:
+
+```bash
+sh scripts/update_requirements.sh
+```
+
+## Running tests
+
+Use `pytest` to run the unit tests after installing the dependencies:
+
+```bash
+pytest
+```

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Simple environment setup script
+python3.12 -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt

--- a/scripts/update_requirements.py
+++ b/scripts/update_requirements.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Synchronize requirements.txt with dependencies in pyproject.toml."""
+from pathlib import Path
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+pyproject_path = ROOT / "pyproject.toml"
+requirements_path = ROOT / "requirements.txt"
+
+with pyproject_path.open("rb") as f:
+    data = tomllib.load(f)
+
+deps = data.get("project", {}).get("dependencies", [])
+
+with requirements_path.open("w") as f:
+    for dep in deps:
+        f.write(dep + "\n")
+
+print(f"Wrote {len(deps)} dependencies to {requirements_path}")

--- a/scripts/update_requirements.sh
+++ b/scripts/update_requirements.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Update requirements.txt from dependencies listed in pyproject.toml
+python scripts/update_requirements.py


### PR DESCRIPTION
## Summary
- document Python 3.12 requirement and installation steps
- add `scripts/setup_env.sh` to automate environment setup
- script `scripts/update_requirements.py` syncs `requirements.txt` with `pyproject.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68401b00cdcc832ebb32a2af601439af