### PR TITLE
Update defaults and enforce per-stage limits

### DIFF
--- a/alpha_framework/alpha_framework_program.py
+++ b/alpha_framework/alpha_framework_program.py
@@ -16,6 +16,7 @@ from .alpha_framework_types import (
     OP_REGISTRY # Required for OpSpec access
 )
 from .alpha_framework_op import Op
+from . import program_logic_generation
 from .program_logic_generation import generate_random_program_logic
 from .program_logic_variation import mutate_program_logic, crossover_program_logic
 
@@ -73,9 +74,21 @@ class AlphaProgram:
         feature_vars: Dict[str, TypeId],
         state_vars: Dict[str, TypeId],
         max_total_ops: int = 32,
-        rng: Optional[np.random.Generator] = None
+        rng: Optional[np.random.Generator] = None,
+        max_setup_ops: int = program_logic_generation.MAX_SETUP_OPS,
+        max_predict_ops: int = program_logic_generation.MAX_PREDICT_OPS,
+        max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS,
     ) -> "AlphaProgram":
-        return generate_random_program_logic(cls, feature_vars, state_vars, max_total_ops, rng)
+        return generate_random_program_logic(
+            cls,
+            feature_vars,
+            state_vars,
+            max_total_ops,
+            rng,
+            max_setup_ops,
+            max_predict_ops,
+            max_update_ops,
+        )
 
     def copy(self) -> "AlphaProgram":
         new_prog = AlphaProgram(
@@ -89,12 +102,42 @@ class AlphaProgram:
     def mutate(self, feature_vars: Dict[str, TypeId], state_vars: Dict[str, TypeId],
                prob_add: float = 0.2, prob_remove: float = 0.2,
                prob_change_op: float = 0.3, prob_change_inputs: float = 0.3,
-               max_total_ops: int = 48, rng: Optional[np.random.Generator] = None) -> "AlphaProgram":
-        return mutate_program_logic(self, feature_vars, state_vars, prob_add, prob_remove,
-                                    prob_change_op, prob_change_inputs, max_total_ops, rng)
+               max_total_ops: int = 87,
+               rng: Optional[np.random.Generator] = None,
+               max_setup_ops: int = program_logic_generation.MAX_SETUP_OPS,
+               max_predict_ops: int = program_logic_generation.MAX_PREDICT_OPS,
+               max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS) -> "AlphaProgram":
+        return mutate_program_logic(
+            self,
+            feature_vars,
+            state_vars,
+            prob_add,
+            prob_remove,
+            prob_change_op,
+            prob_change_inputs,
+            max_total_ops,
+            rng,
+            max_setup_ops,
+            max_predict_ops,
+            max_update_ops,
+        )
 
-    def crossover(self, other: "AlphaProgram", rng: Optional[np.random.Generator] = None) -> "AlphaProgram":
-        return crossover_program_logic(self, other, rng)
+    def crossover(
+        self,
+        other: "AlphaProgram",
+        rng: Optional[np.random.Generator] = None,
+        max_setup_ops: int = program_logic_generation.MAX_SETUP_OPS,
+        max_predict_ops: int = program_logic_generation.MAX_PREDICT_OPS,
+        max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS,
+    ) -> "AlphaProgram":
+        return crossover_program_logic(
+            self,
+            other,
+            rng,
+            max_setup_ops,
+            max_predict_ops,
+            max_update_ops,
+        )
 
     @staticmethod
     def _get_default_feature_vars() -> Dict[str, TypeId]:

--- a/alpha_framework/program_logic_variation.py
+++ b/alpha_framework/program_logic_variation.py
@@ -11,6 +11,11 @@ from .alpha_framework_types import (
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
 )
 from .alpha_framework_op import Op
+from .program_logic_generation import (
+    MAX_SETUP_OPS,
+    MAX_PREDICT_OPS,
+    MAX_UPDATE_OPS,
+)
 
 
 if TYPE_CHECKING:
@@ -25,8 +30,11 @@ def mutate_program_logic(
     prob_remove: float = 0.2,
     prob_change_op: float = 0.3,
     prob_change_inputs: float = 0.3,
-    max_total_ops: int = 48,
-    rng: Optional[np.random.Generator] = None
+    max_total_ops: int = 87,
+    rng: Optional[np.random.Generator] = None,
+    max_setup_ops: int = MAX_SETUP_OPS,
+    max_predict_ops: int = MAX_PREDICT_OPS,
+    max_update_ops: int = MAX_UPDATE_OPS,
 ) -> AlphaProgram:
     """
     Core logic for AlphaProgram.mutate method.
@@ -38,12 +46,13 @@ def mutate_program_logic(
     chosen_block_name = rng.choice(block_name_choices)
 
     block_ref_map = {"setup": new_prog.setup, "predict": new_prog.predict_ops, "update": new_prog.update_ops}
+    block_limit_map = {"setup": max_setup_ops, "predict": max_predict_ops, "update": max_update_ops}
     chosen_block_ops_list = block_ref_map[chosen_block_name]
 
     current_total_ops = sum(len(b) for b in block_ref_map.values())
 
     possible_mutations = []
-    if current_total_ops < max_total_ops:
+    if current_total_ops < max_total_ops and len(chosen_block_ops_list) < block_limit_map[chosen_block_name]:
         possible_mutations.append("add")
     if len(chosen_block_ops_list) > (1 if chosen_block_name == "predict" else 0) :
         possible_mutations.append("remove")
@@ -251,6 +260,11 @@ def mutate_program_logic(
     if spec.is_cross_sectional_aggregator:
         new_prog.predict_ops[-1] = Op(FINAL_PREDICTION_VECTOR_NAME, "cs_rank", ("vol10_t",))
 
+    # Enforce per-stage limits
+    new_prog.setup = new_prog.setup[:max_setup_ops]
+    new_prog.predict_ops = new_prog.predict_ops[:max_predict_ops]
+    new_prog.update_ops = new_prog.update_ops[:max_update_ops]
+
     new_prog._vars_info_cache = None
     return new_prog
 
@@ -258,7 +272,10 @@ def mutate_program_logic(
 def crossover_program_logic(
     self_prog: AlphaProgram, # Instance of AlphaProgram (parent 1)
     other_prog: AlphaProgram, # Instance of AlphaProgram (parent 2)
-    rng: Optional[np.random.Generator] = None
+    rng: Optional[np.random.Generator] = None,
+    max_setup_ops: int = MAX_SETUP_OPS,
+    max_predict_ops: int = MAX_PREDICT_OPS,
+    max_update_ops: int = MAX_UPDATE_OPS,
 ) -> AlphaProgram:
     """
     Core logic for AlphaProgram.crossover method.
@@ -318,6 +335,11 @@ def crossover_program_logic(
             source_for_assign = rng.choice(available_vectors) if available_vectors else \
                                 (CROSS_SECTIONAL_FEATURE_VECTOR_NAMES[0] if CROSS_SECTIONAL_FEATURE_VECTOR_NAMES else "opens_t")
             child.predict_ops.append(Op(FINAL_PREDICTION_VECTOR_NAME, "assign_vector", (source_for_assign,)))
+
+    # Enforce per-stage limits
+    child.setup = child.setup[:max_setup_ops]
+    child.predict_ops = child.predict_ops[:max_predict_ops]
+    child.update_ops = child.update_ops[:max_update_ops]
 
     child._vars_info_cache = None
     return child

--- a/config.py
+++ b/config.py
@@ -27,19 +27,22 @@ class DataConfig:
 class EvolutionConfig(DataConfig):
     generations: int = 10
     seed: int = 42
-    pop_size: int = 96
-    tournament_k: int = 3
-    elite_keep: int = 4
+    pop_size: int = 100
+    tournament_k: int = 10
+    elite_keep: int = 1
     hof_size: int = 20
     quiet: bool = False
 
     # breeding / variation
-    p_mut: float = 0.55
-    p_cross: float = 0.6
+    p_mut: float = 0.9
+    p_cross: float = 0.0
     fresh_rate: float = 0.12
 
     # complexity / similarity guards
-    max_ops: int = 48
+    max_ops: int = 87
+    max_setup_ops: int = 21
+    max_predict_ops: int = 21
+    max_update_ops: int = 45
     parsimony_penalty: float = 0.0001
     corr_penalty_w: float = 0.35
     corr_cutoff: float = 0.15

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -71,10 +71,24 @@ INITIAL_STATE_VARS: Dict[str, TypeId] = {
 }
 
 def _random_prog(cfg: EvoConfig) -> AlphaProgram: # Signature changed
-    return AlphaProgram.random_program(FEATURE_VARS, INITIAL_STATE_VARS, max_total_ops=cfg.max_ops)
+    return AlphaProgram.random_program(
+        FEATURE_VARS,
+        INITIAL_STATE_VARS,
+        max_total_ops=cfg.max_ops,
+        max_setup_ops=cfg.max_setup_ops,
+        max_predict_ops=cfg.max_predict_ops,
+        max_update_ops=cfg.max_update_ops,
+    )
 
 def _mutate_prog(p: AlphaProgram, cfg: EvoConfig) -> AlphaProgram: # Signature changed
-    return p.mutate(FEATURE_VARS, INITIAL_STATE_VARS, max_total_ops=cfg.max_ops)
+    return p.mutate(
+        FEATURE_VARS,
+        INITIAL_STATE_VARS,
+        max_total_ops=cfg.max_ops,
+        max_setup_ops=cfg.max_setup_ops,
+        max_predict_ops=cfg.max_predict_ops,
+        max_update_ops=cfg.max_update_ops,
+    )
 
 ###############################################################################
 # EVOLVE LOOP ##############################################################
@@ -190,7 +204,12 @@ def evolve(cfg: EvoConfig) -> List[Tuple[AlphaProgram, float]]: # Signature chan
 
                 child: AlphaProgram
                 if random.random() < cfg.p_cross:
-                    child = parent_a.crossover(parent_b)
+                    child = parent_a.crossover(
+                        parent_b,
+                        max_setup_ops=cfg.max_setup_ops,
+                        max_predict_ops=cfg.max_predict_ops,
+                        max_update_ops=cfg.max_update_ops,
+                    )
                 else:
                     child = parent_a.copy() if random.random() < 0.5 else parent_b.copy()
                 

--- a/tests/test_random_program.py
+++ b/tests/test_random_program.py
@@ -1,6 +1,11 @@
 import numpy as np
 
 from alpha_framework import AlphaProgram, FINAL_PREDICTION_VECTOR_NAME
+from alpha_framework.program_logic_generation import (
+    MAX_SETUP_OPS,
+    MAX_PREDICT_OPS,
+    MAX_UPDATE_OPS,
+)
 
 
 def test_random_program_final_op_vector():
@@ -15,3 +20,18 @@ def test_random_program_final_op_vector():
         after_setup = prog._trace_vars_for_block(prog.setup, {**feature_vars, **state_vars})
         vars_after_predict = prog._trace_vars_for_block(prog.predict_ops, after_setup)
         assert vars_after_predict[FINAL_PREDICTION_VECTOR_NAME] == "vector"
+
+
+def test_random_program_respects_block_limits():
+    feature_vars = AlphaProgram._get_default_feature_vars()
+    state_vars = {"dummy": "scalar"}
+    rng = np.random.default_rng(1)
+    prog = AlphaProgram.random_program(
+        feature_vars,
+        state_vars,
+        max_total_ops=200,
+        rng=rng,
+    )
+    assert len(prog.setup) <= MAX_SETUP_OPS
+    assert len(prog.predict_ops) <= MAX_PREDICT_OPS
+    assert len(prog.update_ops) <= MAX_UPDATE_OPS


### PR DESCRIPTION
## Summary
- bump evolution defaults (pop size, mutation prob, etc.)
- enforce per-stage op limits when generating, mutating and crossing programs
- propagate limits through evolution loop
- add tests for stage limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684076f210ac832ebf30d4cdbcc89c5c