### PR TITLE
Add LRU caching for program evaluation

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,6 +53,9 @@ class EvolutionConfig(DataConfig):
     early_abort_t: float = 5e-2
     scale: str = "zscore"
 
+    # evaluation cache
+    eval_cache_size: int = 128
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  cross-sectional back-test

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -55,7 +55,7 @@ def _sync_evolution_configs_from_config(cfg: EvoConfig): # Renamed and signature
         corr_penalty_weight=cfg.corr_penalty_w,
         corr_cutoff=cfg.corr_cutoff
     )
-    initialize_evaluation_cache()
+    initialize_evaluation_cache(cfg.eval_cache_size)
 
 
 FEATURE_VARS: Dict[str, TypeId] = {name: "vector" for name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES}
@@ -128,8 +128,8 @@ def evolve(cfg: EvoConfig) -> List[Tuple[AlphaProgram, float]]: # Signature chan
             if not eval_results or eval_results[0][1] <= -float('inf'):
                 print(f"Gen {gen+1:3d} | No valid programs. Restarting population and HOF.")
                 pop = [_random_prog(cfg) for _ in range(cfg.pop_size)]
-                initialize_evaluation_cache() 
-                clear_hof() 
+                initialize_evaluation_cache(cfg.eval_cache_size)
+                clear_hof()
                 gen_eval_times_history.clear()
                 continue
 

--- a/tests/test_evaluation_logic.py
+++ b/tests/test_evaluation_logic.py
@@ -3,15 +3,19 @@ import pandas as pd
 from collections import OrderedDict
 import pytest
 
-from evolution_components.evaluation_logic import _safe_corr_eval, evaluate_program
+from evolution_components.evaluation_logic import (
+    _safe_corr_eval,
+    evaluate_program,
+    initialize_evaluation_cache,
+)
 from alpha_framework import AlphaProgram, Op, FINAL_PREDICTION_VECTOR_NAME
 
 
-def build_simple_program():
+def build_simple_program(suffix: str = ""):
     ops = [
-        Op("twos", "add", ("const_1", "const_1")),
-        Op("scaled", "vec_mul_scalar", ("opens_t", "twos")),
-        Op(FINAL_PREDICTION_VECTOR_NAME, "vec_add_scalar", ("scaled", "const_neg_1")),
+        Op(f"twos{suffix}", "add", ("const_1", "const_1")),
+        Op(f"scaled{suffix}", "vec_mul_scalar", ("opens_t", f"twos{suffix}")),
+        Op(FINAL_PREDICTION_VECTOR_NAME, "vec_add_scalar", (f"scaled{suffix}", "const_neg_1")),
     ]
     return AlphaProgram(setup=[], predict_ops=ops, update_ops=[])
 
@@ -98,3 +102,76 @@ def test_evaluate_program_basic(monkeypatch):
     expected_score = 1.0 - 0.002 * prog.size / 32
     assert score == pytest.approx(expected_score)
     assert mean_ic == pytest.approx(1.0)
+
+
+class CountingDH:
+    def __init__(self):
+        self.index = pd.RangeIndex(3)
+        self.dfs = OrderedDict({
+            "A": pd.DataFrame({
+                "opens": [1.0, 2.0, 3.0],
+                "ret_fwd": [0.1, 0.2, 0.3],
+            }, index=self.index),
+            "B": pd.DataFrame({
+                "opens": [2.0, 3.0, 4.0],
+                "ret_fwd": [0.2, 0.3, 0.4],
+            }, index=self.index),
+        })
+        self.calls = 0
+
+    def get_aligned_dfs(self):
+        self.calls += 1
+        return self.dfs
+
+    def get_common_time_index(self):
+        return self.index
+
+    def get_stock_symbols(self):
+        return list(self.dfs.keys())
+
+    def get_n_stocks(self):
+        return len(self.dfs)
+
+    def get_eval_lag(self):
+        return 1
+
+
+class DummyHOF:
+    def get_correlation_penalty_with_hof(self, ts):
+        return 0.0
+
+
+def test_eval_cache_hit():
+    prog = build_simple_program("a")
+    dh = CountingDH()
+    hof = DummyHOF()
+    initialize_evaluation_cache(max_size=2)
+
+    first = evaluate_program(prog, dh, hof, {})
+    assert dh.calls == 1
+
+    second = evaluate_program(prog, dh, hof, {})
+    assert dh.calls == 1
+    assert first == second
+
+
+def test_eval_cache_eviction():
+    prog1 = build_simple_program("a")
+    prog2 = build_simple_program("b")
+    prog3 = build_simple_program("c")
+    dh = CountingDH()
+    hof = DummyHOF()
+    initialize_evaluation_cache(max_size=2)
+
+    evaluate_program(prog1, dh, hof, {})
+    evaluate_program(prog2, dh, hof, {})
+    assert dh.calls == 2
+
+    evaluate_program(prog3, dh, hof, {})  # Evicts prog1
+    assert dh.calls == 3
+
+    evaluate_program(prog2, dh, hof, {})  # Cached
+    assert dh.calls == 3
+
+    evaluate_program(prog1, dh, hof, {})  # Needs recompute
+    assert dh.calls == 4


### PR DESCRIPTION
## Summary
- use an OrderedDict based LRU cache for evaluation results
- expose `eval_cache_size` in `EvolutionConfig`
- forward cache size when configuring evolution and when restarting search
- expand evaluation logic tests to cover cache hits and eviction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684077011e44832e95a9d478af92c97c