### PR TITLE
Add train/validation/test split utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ Use `pytest` to run the unit tests after installing the dependencies:
 ```bash
 pytest
 ```
+
+## Data handling
+
+Aligned OHLCV data is loaded from a directory of CSV files. The
+`full_overlap` strategy is recommended as it keeps the maximum number of
+datapoints shared across all symbols.  After alignment you can obtain
+train/validation/test splits via `evolution_components.get_data_splits`.

--- a/evolution_components/__init__.py
+++ b/evolution_components/__init__.py
@@ -4,6 +4,7 @@ from .data_handling import (
     get_common_time_index,
     get_stock_symbols,
     get_n_stocks,
+    get_data_splits,
 )
 from .evaluation_logic import evaluate_program, initialize_evaluation_cache
 from .hall_of_fame_manager import (
@@ -22,6 +23,7 @@ __all__ = [
     "get_common_time_index",
     "get_stock_symbols",
     "get_n_stocks",
+    "get_data_splits",
     "evaluate_program",
     "initialize_evaluation_cache",
     "initialize_hof",

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -1,6 +1,6 @@
 import pytest
 
-from evolution_components.data_handling import _load_and_align_data_internal
+from evolution_components.data_handling import _load_and_align_data_internal, get_data_splits, initialize_data
 from backtesting_components.data_handling_bt import load_and_align_data_for_backtest
 
 DATA_DIR = "tests/data/good"
@@ -46,3 +46,15 @@ def test_backtest_missing_columns_raises():
 def test_backtest_insufficient_overlap_raises():
     with pytest.raises(SystemExit):
         load_and_align_data_for_backtest(BAD_OVERLAP_DIR, "common_1200", 4)
+
+
+def test_get_data_splits_returns_expected_lengths():
+    initialize_data(DATA_DIR, "common_1200", 3, 1)
+    train, val, test = get_data_splits(1, 1, 1)
+
+    for split in (train, val, test):
+        for df in split.values():
+            assert len(df) == 2  # 1 eval step + 1 lag
+
+    assert train["AAA"].index[-1] == val["AAA"].index[0]
+    assert val["AAA"].index[-1] == test["AAA"].index[0]


### PR DESCRIPTION
## Summary
- add `get_data_splits` utility in `data_handling`
- expose new function via package `__init__`
- document recommended `full_overlap` alignment strategy
- test the new split helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684089dcb658832ea072a0eeb9b522ad