### PR TITLE
Align config with paper defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Use `pytest` to run the unit tests after installing the dependencies:
 pytest
 ```
 
+## Default hyperparameters
+
+The values in `config.py` mirror the meta‑hyper‑parameters listed in
+Section 4.1 of the reproduction guide:
+
+* population size **100**
+* tournament size **10**
+* mutation probability **0.9**
+* setup, predict and update operation limits **21/21/45**
+* correlation cutoff for Hall of Fame entries **15 %**
+
 ## Data handling
 
 Aligned OHLCV data is loaded from a directory of CSV files. The

--- a/config.py
+++ b/config.py
@@ -39,10 +39,14 @@ class EvolutionConfig(DataConfig):
     fresh_rate: float = 0.12
 
     # complexity / similarity guards
+    # operation limits (Section 4.1 of the paper)
     max_ops: int = 87
     max_setup_ops: int = 21
     max_predict_ops: int = 21
     max_update_ops: int = 45
+    max_scalar_operands: int = 10
+    max_vector_operands: int = 16
+    max_matrix_operands: int = 4
     parsimony_penalty: float = 0.0001
     corr_penalty_w: float = 0.35
     corr_cutoff: float = 0.15

--- a/evolution_components/hall_of_fame_manager.py
+++ b/evolution_components/hall_of_fame_manager.py
@@ -15,7 +15,8 @@ _keep_dupes_in_hof_config: bool = False # Corresponds to KEEP_DUPES_IN_HOF_CONFI
 # For correlation penalty
 _hof_processed_prediction_timeseries_for_corr: List[np.ndarray] = []
 _hof_corr_fingerprints: List[str] = []  # keep order to manage eviction
-_corr_penalty_config: Dict[str, float] = {"weight": 0.25, "cutoff": 0.20}
+# Default correlation penalty configuration mirrors Section 9
+_corr_penalty_config: Dict[str, float] = {"weight": 0.35, "cutoff": 0.15}
 
 
 def initialize_hof(max_size: int, keep_dupes: bool, corr_penalty_weight: float, corr_cutoff: float):


### PR DESCRIPTION
## Summary
- document default hyperparameters
- expose operand limits in `EvolutionConfig`
- default Hall of Fame correlation cutoff to 15%

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d3570ed4832e946ce10d719756e3