### PR TITLE
Implement sector grouping helper

### DIFF
--- a/evolution_components/__init__.py
+++ b/evolution_components/__init__.py
@@ -5,6 +5,7 @@ from .data_handling import (
     get_stock_symbols,
     get_n_stocks,
     get_data_splits,
+    get_sector_groups,
 )
 from .evaluation_logic import evaluate_program, initialize_evaluation_cache
 from .hall_of_fame_manager import (
@@ -24,6 +25,7 @@ __all__ = [
     "get_stock_symbols",
     "get_n_stocks",
     "get_data_splits",
+    "get_sector_groups",
     "evaluate_program",
     "initialize_evaluation_cache",
     "initialize_hof",

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -1,6 +1,11 @@
 import pytest
 
-from evolution_components.data_handling import _load_and_align_data_internal, get_data_splits, initialize_data
+from evolution_components.data_handling import (
+    _load_and_align_data_internal,
+    get_data_splits,
+    initialize_data,
+    get_sector_groups,
+)
 from backtesting_components.data_handling_bt import load_and_align_data_for_backtest
 
 DATA_DIR = "tests/data/good"
@@ -58,3 +63,13 @@ def test_get_data_splits_returns_expected_lengths():
 
     assert train["AAA"].index[-1] == val["AAA"].index[0]
     assert val["AAA"].index[-1] == test["AAA"].index[0]
+
+
+def test_get_sector_groups_example_symbols():
+    symbols = [
+        "BINANCE_BTCUSDT, 240",
+        "BINANCE_ETHUSDT, 240",
+        "BYBIT_BONKUSDT, 240",
+    ]
+    groups = get_sector_groups(symbols)
+    assert list(groups) == [0, 1, 3]


### PR DESCRIPTION
## Summary
- add `get_sector_groups` to produce token sector ids
- export helper through evolution_components API
- cover new helper in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e760e180832e95657458c555329d