### PR TITLE
Add CLI flags for operation limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Section 4.1 of the reproduction guide:
 * tournament size **10**
 * mutation probability **0.9**
 * setup, predict and update operation limits **21/21/45**
+* scalar/vector/matrix operand limits **10/16/4**
+* evaluation cache size **128**
 * correlation cutoff for Hall of Fame entries **15 %**
 
 ## Data handling

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -3,6 +3,15 @@
 run_pipeline.py  – evolve cross-sectional alphas **and** back-test them.
 Usage example:
     uv run run_pipeline.py 5 --max_lookback_data_option full_overlap --fee 0.5
+
+Operation limit flags:
+    --max_setup_ops
+    --max_predict_ops
+    --max_update_ops
+    --max_scalar_operands
+    --max_vector_operands
+    --max_matrix_operands
+    --eval_cache_size
 """
 
 from __future__ import annotations
@@ -35,6 +44,12 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig]:
     p.add_argument("--elite_keep",         type=int,   default=argparse.SUPPRESS)
     p.add_argument("--fresh_rate",         type=float, default=argparse.SUPPRESS)
     p.add_argument("--max_ops",            type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--max_setup_ops",      type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--max_predict_ops",    type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--max_update_ops",     type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--max_scalar_operands", type=int,  default=argparse.SUPPRESS)
+    p.add_argument("--max_vector_operands", type=int,  default=argparse.SUPPRESS)
+    p.add_argument("--max_matrix_operands", type=int,  default=argparse.SUPPRESS)
     p.add_argument("--parsimony_penalty",  type=float, default=argparse.SUPPRESS)
     p.add_argument("--corr_penalty_w",     type=float, default=argparse.SUPPRESS)
     p.add_argument("--corr_cutoff",        type=float, default=argparse.SUPPRESS)
@@ -50,6 +65,7 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig]:
                                                      default=argparse.SUPPRESS)
     p.add_argument("--quiet",              action="store_true", default=argparse.SUPPRESS)
     p.add_argument("--workers",            type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--eval_cache_size",    type=int,   default=argparse.SUPPRESS)
 
     # ───► shared data flags
     p.add_argument("--data_dir",                 default=argparse.SUPPRESS)


### PR DESCRIPTION
## Summary
- expose additional operation limit arguments in `run_pipeline.py`
- document default operand limits and cache size in README
- mention operation limit flags in `run_pipeline.py` help text
- enable passing new args through `parse_args`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ec277158832e9fdf5b72692cf279