### PR TITLE
Add parse_args tests

### DIFF
--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,0 +1,20 @@
+import sys
+from run_pipeline import parse_args
+
+
+def test_parse_args_defaults(monkeypatch):
+    argv = ["run_pipeline.py", "5"]
+    monkeypatch.setattr(sys, "argv", argv)
+    evo_cfg, bt_cfg, debug = parse_args()
+    assert evo_cfg.generations == 5
+    # check a couple defaults
+    assert evo_cfg.seed == 42
+    assert bt_cfg.top_to_backtest == 10
+    assert debug is False
+
+
+def test_parse_args_debug_flag(monkeypatch):
+    argv = ["run_pipeline.py", "3", "--debug_prints"]
+    monkeypatch.setattr(sys, "argv", argv)
+    _, _, debug = parse_args()
+    assert debug is True


### PR DESCRIPTION
## Summary
- test run_pipeline.parse_args with default arguments
- verify optional debug flag passes through

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840eecb85c0832ea6a76be4c65db0fd