### PR TITLE
Add baseline training option to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Run the full pipeline for five generations:
 
 ```bash
 uv run run_pipeline.py 5 --max_lookback_data_option full_overlap --fee 0.5 --debug_prints
+
+Use `--run_baselines` to additionally train the RankLSTM and GA tree baselines.
 ```
 
 The `--debug_prints` flag forwards verbose output to the back-tester.

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -5,16 +5,25 @@ from run_pipeline import parse_args
 def test_parse_args_defaults(monkeypatch):
     argv = ["run_pipeline.py", "5"]
     monkeypatch.setattr(sys, "argv", argv)
-    evo_cfg, bt_cfg, debug = parse_args()
+    evo_cfg, bt_cfg, debug, run_baselines = parse_args()
     assert evo_cfg.generations == 5
     # check a couple defaults
     assert evo_cfg.seed == 42
     assert bt_cfg.top_to_backtest == 10
     assert debug is False
+    assert run_baselines is False
 
 
 def test_parse_args_debug_flag(monkeypatch):
     argv = ["run_pipeline.py", "3", "--debug_prints"]
     monkeypatch.setattr(sys, "argv", argv)
-    _, _, debug = parse_args()
+    _, _, debug, run_baselines = parse_args()
     assert debug is True
+    assert run_baselines is False
+
+
+def test_parse_args_run_baselines(monkeypatch):
+    argv = ["run_pipeline.py", "3", "--run_baselines"]
+    monkeypatch.setattr(sys, "argv", argv)
+    _, _, _, run_baselines = parse_args()
+    assert run_baselines is True


### PR DESCRIPTION
## Summary
- allow `run_pipeline.py` to optionally train RankLSTM and GA baselines
- save baseline metrics in JSON via `_train_baselines`
- expose `--run_baselines` flag in `parse_args`
- update tests for new argument
- document the flag in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ef0c2c9c832eace3721cdc901943