### PR TITLE
Add backtest helpers for baseline models

### DIFF
--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -1,6 +1,7 @@
 import numpy as np
-from baselines.ga_tree import train_ga_tree
-from baselines.rank_lstm import train_rank_lstm
+import pytest
+from baselines.ga_tree import train_ga_tree, backtest_ga_tree
+from baselines.rank_lstm import train_rank_lstm, backtest_rank_lstm
 from baselines.rsr import train_rsr
 
 DATA_DIR = "tests/data/good"
@@ -18,6 +19,13 @@ def test_ga_tree():
 def test_rank_lstm():
     metrics = train_rank_lstm(DATA_DIR, seq_lens=(2,), lambdas=(0.1,))
     _check_metrics(metrics)
+
+
+def test_backtest_helpers():
+    ga_metrics = backtest_ga_tree(DATA_DIR)
+    rl_metrics = backtest_rank_lstm(DATA_DIR, seq_len=1, lmbd=0.1)
+    assert ga_metrics["Sharpe"] == pytest.approx(-3.0341598716)
+    assert rl_metrics["Sharpe"] == pytest.approx(2.3333333)
 
 
 def test_rsr():


### PR DESCRIPTION
## Summary
- implement `backtest_ga_tree` and `backtest_rank_lstm` using aligned data splits
- compute Sharpe via simple backtest in GA-tree and rank LSTM helpers
- call these helpers from the training functions
- extend baseline tests to cover the new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684176f773e8832ebce93609222357e0