### PR TITLE
Display baseline metrics in pipeline

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -130,6 +130,13 @@ def _train_baselines(data_dir: str, out_dir: Path) -> None:
         "ga_tree": train_ga_tree(data_dir),
         "rank_lstm": train_rank_lstm(data_dir),
     }
+    name_map = {
+        "ga_tree": "GA tree",
+        "rank_lstm": "RankLSTM",
+    }
+    for name, m in metrics.items():
+        nm = name_map.get(name, name)
+        print(f"{nm} IC: {m['IC']:.4f} Sharpe: {m['Sharpe']:.4f}")
     out_file = out_dir / "baseline_metrics.json"
     with open(out_file, "w") as fh:
         json.dump(metrics, fh, indent=2)

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -27,3 +27,12 @@ def test_parse_args_run_baselines(monkeypatch):
     monkeypatch.setattr(sys, "argv", argv)
     _, _, _, run_baselines = parse_args()
     assert run_baselines is True
+
+
+def test_train_baselines_prints(tmp_path, capsys):
+    from run_pipeline import _train_baselines
+
+    _train_baselines("tests/data/good", tmp_path)
+    captured = capsys.readouterr().out
+    assert "GA tree" in captured
+    assert "RankLSTM" in captured


### PR DESCRIPTION
## Summary
- print metrics for each baseline in `run_pipeline._train_baselines`
- verify printed baseline names in a new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417a07e41c832eb744d40d9fdd84a5