### PR TITLE
Add tests for GA tree utils and backtest script

### DIFF
--- a/tests/test_backtest_script.py
+++ b/tests/test_backtest_script.py
@@ -1,0 +1,57 @@
+import pickle
+import sys
+
+import pytest
+
+from backtest_evolved_alphas import parse_args, load_programs_from_pickle
+
+
+# -------------------------------------------------------------------
+# parse_args
+# -------------------------------------------------------------------
+def test_parse_args_defaults(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["backtest_evolved_alphas.py"])
+    cfg, ns = parse_args()
+    assert cfg.top_to_backtest == 10
+    assert ns.input == "evolved_top_alphas.pkl"
+    assert ns.outdir == "evolved_bt_cs_results"
+
+
+def test_parse_args_overrides(monkeypatch):
+    argv = [
+        "backtest_evolved_alphas.py",
+        "--top", "3",
+        "--fee", "0.5",
+        "--scale", "rank",
+        "--data", "data_dir",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cfg, _ = parse_args()
+    assert cfg.top_to_backtest == 3
+    assert cfg.fee == 0.5
+    assert cfg.scale == "rank"
+
+
+# -------------------------------------------------------------------
+# load_programs_from_pickle
+# -------------------------------------------------------------------
+def test_load_programs_from_pickle_valid(tmp_path):
+    data = [("prog1", 0.1), ("prog2", 0.2)]
+    fp = tmp_path / "p.pkl"
+    with open(fp, "wb") as f:
+        pickle.dump(data, f)
+    result = load_programs_from_pickle(1, str(fp))
+    assert result == data[:1]
+
+
+def test_load_programs_from_pickle_missing(tmp_path):
+    with pytest.raises(SystemExit):
+        load_programs_from_pickle(1, str(tmp_path / "missing.pkl"))
+
+
+def test_load_programs_from_pickle_invalid(tmp_path):
+    fp = tmp_path / "bad.pkl"
+    fp.write_text("not a pickle")
+    with pytest.raises(SystemExit):
+        load_programs_from_pickle(1, str(fp))
+

--- a/tests/test_ga_tree_utils.py
+++ b/tests/test_ga_tree_utils.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from baselines.ga_tree import _Node, _tree_predict, _ic, _load_all_csv
+
+
+# -------------------------------------------------------------------
+# _tree_predict
+# -------------------------------------------------------------------
+def test_tree_predict_simple(tmp_path):
+    data = pd.DataFrame({
+        "open": [1, 2, 3],
+        "close": [4, 5, 6],
+    })
+    tree = _Node(np.add, _Node(None, feature="open"), _Node(None, feature="close"))
+    preds = _tree_predict(tree, data)
+    assert preds.tolist() == [5.0, 7.0, 9.0]
+
+
+# -------------------------------------------------------------------
+# _ic edge cases
+# -------------------------------------------------------------------
+def test_ic_zero_std_returns_zero():
+    preds = np.ones(5)
+    rets = np.arange(5, dtype=float)
+    assert _ic(preds, rets) == 0.0
+
+
+def test_ic_zero_std_ret_returns_zero():
+    preds = np.arange(5, dtype=float)
+    rets = np.ones(5)
+    assert _ic(preds, rets) == 0.0
+
+
+# -------------------------------------------------------------------
+# _load_all_csv
+# -------------------------------------------------------------------
+def test_load_all_csv_no_files(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        _load_all_csv(str(tmp_path))
+


### PR DESCRIPTION
## Summary
- add unit tests for ga_tree internals
- add CLI and pickle loader tests for `backtest_evolved_alphas`
- run full test suite with coverage

## Testing
- `pytest -q --cov`

------
https://chatgpt.com/codex/tasks/task_e_6841aeb8c928832eaec7826bfb8fb1ac