### PR TITLE
Add Ops column to backtest summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Use `--run_baselines` to additionally train the RankLSTM and GA tree baselines.
 
 The `--debug_prints` flag forwards verbose output to the back-tester.
 
+Back-test summaries now include an `Ops` column showing the operation count of each alpha.
+
 ## Default hyperparameters
 
 The values in `config.py` mirror the meta‑hyper‑parameters listed in

--- a/backtest_evolved_alphas.py
+++ b/backtest_evolved_alphas.py
@@ -129,6 +129,8 @@ def main() -> None:
                                    else cfg.annualization_factor,
         )
 
+        metrics["Ops"] = prog.size
+
         metrics.update({
             "AlphaID":        f"Alpha_{idx:02d}",
             "OriginalMetric": evo_ic,
@@ -143,12 +145,11 @@ def main() -> None:
 
     # --------------------------------------------------------- save summary
     if results:
-        df = (pd.DataFrame(results)
-                .sort_values("Sharpe", ascending=False))
+        df = pd.DataFrame(results).sort_values("Sharpe", ascending=False)
         summary = Path(cli.outdir) / f"backtest_summary_top{cfg.top_to_backtest}.csv"
         df.to_csv(summary, index=False, float_format="%.4f")
-        print(f"\nBack-test summary written → {summary}")
         print(df.drop(columns=["Program", "Error"], errors="ignore").to_string(index=False))
+        print(f"\nBack-test summary written → {summary}")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- include program operation count in backtest metrics
- print and save backtest summaries with Ops column
- document Ops column in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d92c0834832eadccadedaaf1981a