### PR TITLE
Clamp vec_div_scalar denominator

### DIFF
--- a/alpha_framework/alpha_framework_operators.py
+++ b/alpha_framework/alpha_framework_operators.py
@@ -254,8 +254,11 @@ def _vec_add_scalar(v, s): return v + s
 def _vec_mul_scalar(v, s): return v * s
 
 @register_op("vec_div_scalar", in_types=("vector", "scalar"), out="vector")
-@safe_op # safe_op will handle _clean_num for inputs
-def _vec_div_scalar(v, s): return v / (s if np.abs(s) > 1e-9 else np.copysign(1e-9, s))
+@safe_op  # safe_op will handle _clean_num for inputs
+def _vec_div_scalar(v, s):
+    """Divide vector ``v`` by scalar ``s`` while avoiding zero denominators."""
+    denom = np.sign(s) * max(abs(s), 1e-3)
+    return v / denom
 
 
 # Matrix ops

--- a/tests/test_op_execution.py
+++ b/tests/test_op_execution.py
@@ -4,6 +4,22 @@ import pytest
 from alpha_framework import Op
 
 
+def test_vec_div_scalar_small_denominator():
+    v = np.array([1.0, -2.0, 3.0])
+    buf = {"v": v, "s": 1e-12}
+    Op("out", "vec_div_scalar", ("v", "s")).execute(buf, n_stocks=3)
+    expected = v / 1e-3
+    assert np.allclose(buf["out"], expected)
+
+
+def test_vec_div_scalar_small_negative_denominator():
+    v = np.array([1.0, -2.0, 3.0])
+    buf = {"v": v, "s": -1e-12}
+    Op("out", "vec_div_scalar", ("v", "s")).execute(buf, n_stocks=3)
+    expected = v / -1e-3
+    assert np.allclose(buf["out"], expected)
+
+
 def test_scalar_to_vector_broadcast():
     buf = {"vec": 2.0, "s": 3.0}
     op = Op("out", "vec_mul_scalar", ("vec", "s"))


### PR DESCRIPTION
## Summary
- avoid huge outputs in `vec_div_scalar` by clamping the denominator
- test small positive and negative denominators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841da2e68c0832e84ef6aa1971b20f2