### PR TITLE
Expose evaluation metrics

### DIFF
--- a/evolution_components/__init__.py
+++ b/evolution_components/__init__.py
@@ -7,7 +7,7 @@ from .data_handling import (
     get_data_splits,
     get_sector_groups,
 )
-from .evaluation_logic import evaluate_program, initialize_evaluation_cache
+from .evaluation_logic import evaluate_program, initialize_evaluation_cache, EvalResult
 from .hall_of_fame_manager import (
     initialize_hof,
     add_program_to_hof,
@@ -27,6 +27,7 @@ __all__ = [
     "get_data_splits",
     "get_sector_groups",
     "evaluate_program",
+    "EvalResult",
     "initialize_evaluation_cache",
     "initialize_hof",
     "add_program_to_hof",

--- a/tests/test_hof.py
+++ b/tests/test_hof.py
@@ -3,6 +3,7 @@ import pytest
 
 from alpha_framework import AlphaProgram, Op, FINAL_PREDICTION_VECTOR_NAME
 from evolution_components import hall_of_fame_manager as hof
+from evolution_components.evaluation_logic import EvalResult
 
 
 def make_prog(unique: str) -> AlphaProgram:
@@ -15,12 +16,12 @@ def test_high_corr_program_rejected_from_hof():
 
     prog_a = make_prog("const_1")
     preds_a = np.array([[1.0, 2.0], [3.0, 4.0]])
-    hof.add_program_to_hof(prog_a, fitness=1.0, mean_ic=0.0, processed_preds_matrix=preds_a)
+    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, preds_a))
     assert len(hof._hof_programs_data) == 1
 
     prog_b = make_prog("const_neg_1")
     preds_b = preds_a * 2.0  # perfectly correlated with preds_a
-    hof.add_program_to_hof(prog_b, fitness=0.9, mean_ic=0.0, processed_preds_matrix=preds_b)
+    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, preds_b))
 
     assert len(hof._hof_programs_data) == 1
     assert len(hof._hof_rank_pred_matrix) == 1


### PR DESCRIPTION
## Summary
- return detailed `EvalResult` objects from `evaluate_program`
- track `EvalResult` in the Hall of Fame
- adapt evolutionary loop and printing to use new metrics
- update tests for new data structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e1af5214832e815316629bd13516