### PR TITLE
Expose crypto sector mapping via config

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,31 @@ Dataclass-based “single source of truth” for every pipeline knob.
 * BacktestConfig   – everything the cross-sectional back-tester needs
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict
+
+# Default mapping from token symbol to sector ID used across the project.  The
+# mapping groups major crypto assets into rough "sectors" so relation-based
+# operations can reason about them.  A value of ``-1`` denotes an unknown
+# sector.
+DEFAULT_CRYPTO_SECTOR_MAPPING: Dict[str, int] = {
+    "BTC": 0,  # Core
+    "ETH": 1,
+    "SOL": 1,  # Ecosystem
+    # Altcoins
+    "ADA": 2,
+    "AVA": 2,
+    "SUI": 2,
+    "APT": 2,
+    "INJ": 2,
+    "RNDR": 2,
+    "ARB": 2,
+    "LINK": 2,
+    # Memes
+    "BONK": 3,
+    "DOGE": 3,
+    "PEPE": 3,
+}
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  shared data-handling knobs
@@ -18,6 +42,12 @@ class DataConfig:
     max_lookback_data_option: str = "common_1200"
     min_common_points: int = 1200
     eval_lag: int = 1
+    # Mapping from token symbols to sector IDs used for relation-aware
+    # operations.  It defaults to ``DEFAULT_CRYPTO_SECTOR_MAPPING`` defined
+    # above but can be overridden per configuration instance.
+    sector_mapping: Dict[str, int] = field(
+        default_factory=lambda: DEFAULT_CRYPTO_SECTOR_MAPPING.copy()
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/evolution_components/data_handling.py
+++ b/evolution_components/data_handling.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional, OrderedDict as OrderedDictType
 from collections import OrderedDict
+
+from config import DEFAULT_CRYPTO_SECTOR_MAPPING, DataConfig
 import numpy as np
 import pandas as pd
 
@@ -152,13 +154,6 @@ def get_eval_lag() -> int:
     return _EVAL_LAG_CACHE
 
 
-_DEFAULT_SECTOR_MAPPING = {
-    "BTC": 0,  # Core
-    "ETH": 1, "SOL": 1,  # Ecosystem
-    "ADA": 2, "AVA": 2, "SUI": 2, "APT": 2, "INJ": 2,
-    "RNDR": 2, "ARB": 2, "LINK": 2,  # Altcoins
-    "BONK": 3, "DOGE": 3, "PEPE": 3,  # Memes
-}
 
 
 def _extract_token(sym: str) -> str:
@@ -172,8 +167,11 @@ def _extract_token(sym: str) -> str:
     return token
 
 
-def get_sector_groups(symbols: Optional[List[str]] = None,
-                      mapping: Dict[str, int] | None = None) -> np.ndarray:
+def get_sector_groups(
+    symbols: Optional[List[str]] = None,
+    mapping: Dict[str, int] | None = None,
+    cfg: Optional[DataConfig] = None,
+) -> np.ndarray:
     """Return sector IDs for provided symbols.
 
     If ``symbols`` is ``None`` the currently loaded stock symbols are used.
@@ -185,7 +183,12 @@ def get_sector_groups(symbols: Optional[List[str]] = None,
             raise RuntimeError("Data not initialized. Call initialize_data() first.")
         symbols = _STOCK_SYMBOLS
 
-    sector_map = _DEFAULT_SECTOR_MAPPING if mapping is None else mapping
+    if mapping is not None:
+        sector_map = mapping
+    elif cfg is not None:
+        sector_map = cfg.sector_mapping
+    else:
+        sector_map = DEFAULT_CRYPTO_SECTOR_MAPPING
 
     groups: List[int] = []
     for s in symbols:

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -6,6 +6,7 @@ from evolution_components.data_handling import (
     initialize_data,
     get_sector_groups,
 )
+from config import DEFAULT_CRYPTO_SECTOR_MAPPING
 from backtesting_components.data_handling_bt import load_and_align_data_for_backtest
 
 DATA_DIR = "tests/data/good"
@@ -72,4 +73,9 @@ def test_get_sector_groups_example_symbols():
         "BYBIT_BONKUSDT, 240",
     ]
     groups = get_sector_groups(symbols)
-    assert list(groups) == [0, 1, 3]
+    expected = [
+        DEFAULT_CRYPTO_SECTOR_MAPPING["BTC"],
+        DEFAULT_CRYPTO_SECTOR_MAPPING["ETH"],
+        DEFAULT_CRYPTO_SECTOR_MAPPING["BONK"],
+    ]
+    assert list(groups) == expected


### PR DESCRIPTION
## Summary
- define `DEFAULT_CRYPTO_SECTOR_MAPPING` in `config.py`
- expose mapping through `DataConfig.sector_mapping`
- use the new mapping in `get_sector_groups`
- clean up old mapping constant
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684206817e88832ea25d181b9c4a3b0b