### PR TITLE
Remove volume feature from docs and constants

### DIFF
--- a/Detailed _Implementation_Representation_Guide.md
+++ b/Detailed _Implementation_Representation_Guide.md
@@ -30,7 +30,7 @@ Key ingredients:
 
 1. Moving averages (MA‑5, 10, 20, 30).
 2. Volatility of close prices over the same horizons.
-3. Raw OHLCV: *open, high, low, close, volume*.
+3. Raw OHLCV: *open, high, low, close* (volume unavailable).
 
 ### 2.2 Label
 

--- a/UI_alphas_lab/constants.ts
+++ b/UI_alphas_lab/constants.ts
@@ -10,7 +10,7 @@ export const OP_REGISTRY_KEYS: string[] = [
 ];
 
 export const CROSS_SECTIONAL_FEATURE_VECTOR_NAMES_CONST: string[] = [
-    "opens_t", "highs_t", "lows_t", "closes_t", "volumes_t", "ranges_t",
+    "opens_t", "highs_t", "lows_t", "closes_t", "ranges_t",
     "ma5_t", "ma10_t", "ma20_t", "ma30_t",
     "vol5_t", "vol10_t", "vol20_t", "vol30_t"
 ];


### PR DESCRIPTION
## Summary
- clarify that only OHLC data is available
- update UI constants to drop `volumes_t`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420658c530832e888a1346dd0bc214