### PR TITLE
Add logging setup and CLI verbosity controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Use `--run_baselines` to additionally train the RankLSTM and GA tree baselines.
 
 The `--debug_prints` flag forwards verbose output to the back-tester.
 
+Logging can be controlled globally via `--log-level` and `--log-file`.  The
+`--quiet` and `--debug_prints` flags lower or raise the log verbosity when
+running the pipeline.
+
 Back-test summaries now include an `Ops` column showing the operation count of each alpha.
 
 ## Default hyperparameters

--- a/evolution_components/evaluation_logic.py
+++ b/evolution_components/evaluation_logic.py
@@ -3,6 +3,7 @@ import numpy as np
 from typing import TYPE_CHECKING, Dict, List, Optional, Any, Set
 from collections import OrderedDict
 from dataclasses import dataclass
+import logging
 
 if TYPE_CHECKING:
     from alpha_framework.alpha_framework_program import AlphaProgram # Changed from alpha_program_core
@@ -73,14 +74,16 @@ def configure_evaluation(
     _EVAL_CONFIG["early_abort_xs_threshold"] = early_abort_xs
     _EVAL_CONFIG["early_abort_t_threshold"] = early_abort_t
     _EVAL_CONFIG["ic_scale_method"] = scale_method
-    print(f"Evaluation logic configured: {scale_method=}, {parsimony_penalty=}, etc.")
+    logging.getLogger(__name__).debug(
+        "Evaluation logic configured: %s, %s", scale_method, parsimony_penalty
+    )
 
 
 def initialize_evaluation_cache(max_size: int = 128):
     global _eval_cache, _EVAL_CACHE_MAX_SIZE
     _EVAL_CACHE_MAX_SIZE = max_size
     _eval_cache = OrderedDict()
-    print("Evaluation cache cleared and initialized.")
+    logging.getLogger(__name__).debug("Evaluation cache cleared and initialized.")
 
 def _safe_corr_eval(a: np.ndarray, b: np.ndarray) -> float:  # Specific to evaluation logic's needs
     if not (np.all(np.isfinite(a)) and np.all(np.isfinite(b))):

--- a/evolution_components/hall_of_fame_manager.py
+++ b/evolution_components/hall_of_fame_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import numpy as np
 from typing import TYPE_CHECKING, List, Tuple, Dict, Set # Added Set
 import textwrap # For printing HoF
+import logging
 
 if TYPE_CHECKING:
     from alpha_framework import AlphaProgram
@@ -33,7 +34,13 @@ def initialize_hof(max_size: int, keep_dupes: bool, corr_penalty_weight: float, 
     _hof_rank_pred_matrix = []
     _hof_corr_fingerprints = []
     _corr_penalty_config = {"weight": corr_penalty_weight, "cutoff": corr_cutoff}
-    print(f"Hall of Fame initialized: max_size={max_size}, keep_dupes={keep_dupes}, corr_penalty_w={corr_penalty_weight}, corr_cutoff={corr_cutoff}")
+    logging.getLogger(__name__).info(
+        "Hall of Fame initialized: max_size=%s, keep_dupes=%s, corr_penalty_w=%s, corr_cutoff=%s",
+        max_size,
+        keep_dupes,
+        corr_penalty_weight,
+        corr_cutoff,
+    )
 
 def _safe_corr(a: np.ndarray, b: np.ndarray) -> float:  # Copied from evolve_alphas, will be used for HOF penalty
     if not (np.all(np.isfinite(a)) and np.all(np.isfinite(b))):
@@ -202,15 +209,24 @@ def print_generation_summary(generation: int, population: List[AlphaProgram], ev
     # This is tricky because add_program_to_hof already updates the static HOF.
     # The printing should just reflect the current state of _hof_programs_data.
 
-    print(f"\n★ Generation {generation+1} – Top (up to) {_TOP_TO_SHOW_PRINT} overall from HOF ★")
+    logger = logging.getLogger(__name__)
+    logger.info("\n★ Generation %s – Top (up to) %s overall from HOF ★", generation+1, _TOP_TO_SHOW_PRINT)
     hdr = " Rank | Fitness |  IC  | Ops | Finger  | First 90 chars"
-    print(hdr)
-    print("─" * len(hdr))
+    logger.info(hdr)
+    logger.info("─" * len(hdr))
     
     # Print from the managed _hof_programs_data
     for rk, (fp, metrics, prog) in enumerate(_hof_programs_data[:_TOP_TO_SHOW_PRINT], 1):
         head = textwrap.shorten(prog.to_string(max_len=300), width=90, placeholder="…")
-        print(f" {rk:>4} | {metrics.fitness:+7.4f} | {metrics.mean_ic:+5.3f} | {prog.size:3d} | {fp[:8]} | {head}")
+        logger.info(
+            " %4d | %+7.4f | %+5.3f | %3d | %s | %s",
+            rk,
+            metrics.fitness,
+            metrics.mean_ic,
+            prog.size,
+            fp[:8],
+            head,
+        )
 def clear_hof():
     """Clears all HOF state."""
     global _hof_programs_data, _hof_fingerprints_set, _hof_rank_pred_matrix, _hof_corr_fingerprints
@@ -218,4 +234,4 @@ def clear_hof():
     _hof_fingerprints_set = set()
     _hof_rank_pred_matrix = []
     _hof_corr_fingerprints = []
-    print("Hall of Fame cleared.")
+    logging.getLogger(__name__).info("Hall of Fame cleared.")

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -4,6 +4,7 @@ import time
 from typing import Dict, List, Tuple
 from multiprocessing import Pool, cpu_count
 import numpy as np
+import logging
 
 from alpha_framework import AlphaProgram, TypeId, CROSS_SECTIONAL_FEATURE_VECTOR_NAMES, SCALAR_FEATURE_NAMES
 from evolution_components import (
@@ -147,7 +148,10 @@ def evolve(cfg: EvoConfig) -> List[Tuple[AlphaProgram, float]]: # Signature chan
             print_generation_summary(gen, pop, eval_results)
 
             if not eval_results or eval_results[0][1].fitness <= -float('inf'):
-                print(f"Gen {gen+1:3d} | No valid programs. Restarting population and HOF.")
+                logging.getLogger(__name__).info(
+                    "Gen %s | No valid programs. Restarting population and HOF.",
+                    gen + 1,
+                )
                 pop = [_random_prog(cfg) for _ in range(cfg.pop_size)]
                 initialize_evaluation_cache(cfg.eval_cache_size)
                 clear_hof()
@@ -166,9 +170,15 @@ def evolve(cfg: EvoConfig) -> List[Tuple[AlphaProgram, float]]: # Signature chan
             best_fit = best_metrics.fitness
             best_ic = best_metrics.mean_ic
             best_program_obj = pop[best_prog_idx]
-            print(
-                f"Gen {gen+1:3d} BestThisGenFit {best_fit:+.4f} MeanIC {best_ic:+.4f} Ops {best_program_obj.size:2d} EvalTime {gen_eval_time:.1f}s{eta_str}\n"
-                f"  └─ {best_program_obj.to_string(max_len=100)}"
+            logging.getLogger(__name__).info(
+                "Gen %3d BestThisGenFit %+7.4f MeanIC %+7.4f Ops %2d EvalTime %.1fs%s\n  └─ %s",
+                gen + 1,
+                best_fit,
+                best_ic,
+                best_program_obj.size,
+                gen_eval_time,
+                eta_str,
+                best_program_obj.to_string(max_len=100),
             )
 
             new_pop: List[AlphaProgram] = []
@@ -229,7 +239,9 @@ def evolve(cfg: EvoConfig) -> List[Tuple[AlphaProgram, float]]: # Signature chan
             pop = new_pop
             
     except KeyboardInterrupt:
-        print("\n[Ctrl‑C] Evolution stopped early. Processing current HOF...")
+        logging.getLogger(__name__).info(
+            "[Ctrl‑C] Evolution stopped early. Processing current HOF..."
+        )
     
     final_top_programs_with_ic = get_final_hof_programs()
     return final_top_programs_with_ic

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -1,38 +1,40 @@
 import sys
+import logging
 from run_pipeline import parse_args
 
 
 def test_parse_args_defaults(monkeypatch):
     argv = ["run_pipeline.py", "5"]
     monkeypatch.setattr(sys, "argv", argv)
-    evo_cfg, bt_cfg, debug, run_baselines = parse_args()
+    evo_cfg, bt_cfg, ns = parse_args()
     assert evo_cfg.generations == 5
     # check a couple defaults
     assert evo_cfg.seed == 42
     assert bt_cfg.top_to_backtest == 10
-    assert debug is False
-    assert run_baselines is False
+    assert ns.debug_prints is False
+    assert ns.run_baselines is False
 
 
 def test_parse_args_debug_flag(monkeypatch):
     argv = ["run_pipeline.py", "3", "--debug_prints"]
     monkeypatch.setattr(sys, "argv", argv)
-    _, _, debug, run_baselines = parse_args()
-    assert debug is True
-    assert run_baselines is False
+    _, _, ns = parse_args()
+    assert ns.debug_prints is True
+    assert ns.run_baselines is False
 
 
 def test_parse_args_run_baselines(monkeypatch):
     argv = ["run_pipeline.py", "3", "--run_baselines"]
     monkeypatch.setattr(sys, "argv", argv)
-    _, _, _, run_baselines = parse_args()
-    assert run_baselines is True
+    _, _, ns = parse_args()
+    assert ns.run_baselines is True
 
 
-def test_train_baselines_prints(tmp_path, capsys):
+def test_train_baselines_logs(tmp_path, caplog):
     from run_pipeline import _train_baselines
 
+    caplog.set_level(logging.INFO)
     _train_baselines("tests/data/good", tmp_path)
-    captured = capsys.readouterr().out
-    assert "GA tree" in captured
-    assert "RankLSTM" in captured
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "GA tree" in logged
+    assert "RankLSTM" in logged

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Optional
+
+def setup_logging(level: int = logging.INFO, log_file: Optional[str] = None) -> None:
+    """Configure root logger with timestamped messages.
+
+    Parameters
+    ----------
+    level : int
+        Logging verbosity level.
+    log_file : Optional[str]
+        If given, log messages are also written to this file.
+    """
+    handlers = [logging.StreamHandler()]
+    if log_file:
+        handlers.append(logging.FileHandler(log_file))
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=handlers,
+        force=True,
+    )
+


### PR DESCRIPTION
## Summary
- add new `utils/logging_setup` helper
- expose `--log-level` and `--log-file` in `run_pipeline`
- convert status prints to logging
- update tests and docs for logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cad5f450832e9e65d115373d7af4