### PR TITLE
Add ready-to-run pipeline script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ uv run run_pipeline.py 5 --max_lookback_data_option full_overlap --fee 0.5 --deb
 Use `--run_baselines` to additionally train the RankLSTM and GA tree baselines.
 ```
 
+For a longer run using the parameters described in the paper you can simply run
+
+```bash
+sh scripts/recommended_pipeline.sh
+```
+
+The script expands the meta‑hyper‑parameters and adds a few useful flags like
+`--run_baselines`.
+
 The `--debug_prints` flag forwards verbose output to the back-tester.
 
 Logging can be controlled globally via `--log-level` and `--log-file`.  The

--- a/scripts/recommended_pipeline.sh
+++ b/scripts/recommended_pipeline.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Example invocation of run_pipeline.py using parameters recommended by the
+# AlphaEvolve paper with a few useful extras.
+# Adjust --data_dir as needed.
+uv run run_pipeline.py 10 \
+  --max_lookback_data_option full_overlap \
+  --pop_size 100 \
+  --tournament_k 10 \
+  --p_mut 0.9 \
+  --p_cross 0.0 \
+  --max_setup_ops 21 \
+  --max_predict_ops 21 \
+  --max_update_ops 45 \
+  --max_scalar_operands 10 \
+  --max_vector_operands 16 \
+  --max_matrix_operands 4 \
+  --eval_cache_size 128 \
+  --corr_cutoff 0.15 \
+  --fee 0.5 \
+  --workers 4 \
+  --run_baselines \
+  --debug_prints
+


### PR DESCRIPTION
## Summary
- add `scripts/recommended_pipeline.sh` with parameters from the paper
- mention the helper script in the README for quick usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ceaf44bc832eb87dbd3d0b09fe48