### PR TITLE
Remove constant features from random generation

### DIFF
--- a/alpha_framework/alpha_framework_program.py
+++ b/alpha_framework/alpha_framework_program.py
@@ -142,12 +142,8 @@ class AlphaProgram:
     @staticmethod
     def _get_default_feature_vars() -> Dict[str, TypeId]:
         default_vars = {name: "vector" for name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES}
-        default_vars.update({name: "scalar" for name in SCALAR_FEATURE_NAMES})
-        # Ensure base constants are present, though SCALAR_FEATURE_NAMES should cover them
-        if "const_1" not in default_vars:
-            default_vars["const_1"] = "scalar"
-        if "const_neg_1" not in default_vars:
-            default_vars["const_neg_1"] = "scalar"
+        # Do not include constant scalar features by default.  They are still
+        # available via SCALAR_FEATURE_NAMES if callers need them explicitly.
         return default_vars
 
     def new_state(self) -> Dict[str, Union[np.ndarray, float]]:

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -61,11 +61,8 @@ def _sync_evolution_configs_from_config(cfg: EvoConfig): # Renamed and signature
 
 
 FEATURE_VARS: Dict[str, TypeId] = {name: "vector" for name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES}
-FEATURE_VARS.update({name: "scalar" for name in SCALAR_FEATURE_NAMES})
-if "const_1" not in FEATURE_VARS:
-    FEATURE_VARS["const_1"] = "scalar"
-if "const_neg_1" not in FEATURE_VARS:
-    FEATURE_VARS["const_neg_1"] = "scalar"
+# Constant scalar features are deliberately excluded to align with the
+# reference paper.  They remain accessible via SCALAR_FEATURE_NAMES if needed.
 
 INITIAL_STATE_VARS: Dict[str, TypeId] = {
     "prev_s1_vec": "vector",

--- a/tests/test_random_program.py
+++ b/tests/test_random_program.py
@@ -10,6 +10,7 @@ from alpha_framework.program_logic_generation import (
 
 def test_random_program_final_op_vector():
     feature_vars = AlphaProgram._get_default_feature_vars()
+    feature_vars.update({"const_1": "scalar", "const_neg_1": "scalar"})
     state_vars = {"dummy": "scalar"}
     rng = np.random.default_rng(0)
     for _ in range(20):
@@ -24,6 +25,7 @@ def test_random_program_final_op_vector():
 
 def test_random_program_respects_block_limits():
     feature_vars = AlphaProgram._get_default_feature_vars()
+    feature_vars.update({"const_1": "scalar", "const_neg_1": "scalar"})
     state_vars = {"dummy": "scalar"}
     rng = np.random.default_rng(1)
     prog = AlphaProgram.random_program(


### PR DESCRIPTION
## Summary
- avoid automatically including constant features when building default feature vars
- exclude constant scalar features from the evolution pipeline
- update random program tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cedb106c832eaa7e42d9f61b9bff