### PR TITLE
Add sector group feature

### DIFF
--- a/alpha_framework/alpha_framework_types.py
+++ b/alpha_framework/alpha_framework_types.py
@@ -12,6 +12,7 @@ CROSS_SECTIONAL_FEATURE_VECTOR_NAMES = [
     "opens_t", "highs_t", "lows_t", "closes_t", "ranges_t",
     "ma5_t", "ma10_t", "ma20_t", "ma30_t",
     "vol5_t", "vol10_t", "vol20_t", "vol30_t",
+    "sector_id_vector",
 ]
 SCALAR_FEATURE_NAMES = ["const_1", "const_neg_1"]
 


### PR DESCRIPTION
## Summary
- add `sector_id_vector` to CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
- compute sector group vectors in evaluation logic
- expose groups in tests with dummy data handlers
- test that the sector id vector is available in evolved programs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d0ac3438832e989c52196ecd01de