### PR TITLE
Add generation info to Hall of Fame output

### DIFF
--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -6,7 +6,7 @@ from multiprocessing import Pool, cpu_count
 import numpy as np
 import logging
 
-from alpha_framework import AlphaProgram, TypeId, CROSS_SECTIONAL_FEATURE_VECTOR_NAMES, SCALAR_FEATURE_NAMES
+from alpha_framework import AlphaProgram, TypeId, CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
 from evolution_components import (
     initialize_data, 
     evaluate_program, 
@@ -159,7 +159,7 @@ def evolve(cfg: EvoConfig) -> List[Tuple[AlphaProgram, float]]: # Signature chan
                 best_preds_matrix_this_gen = best_metrics_this_gen.processed_predictions
                 best_program_instance_this_gen = pop[best_prog_idx_this_gen]
 
-                add_program_to_hof(best_program_instance_this_gen, best_metrics_this_gen)
+                add_program_to_hof(best_program_instance_this_gen, best_metrics_this_gen, gen)
 
                 if best_preds_matrix_this_gen is not None:
                     update_correlation_hof(best_program_instance_this_gen.fingerprint, best_preds_matrix_this_gen)

--- a/tests/test_hof.py
+++ b/tests/test_hof.py
@@ -16,12 +16,12 @@ def test_high_corr_program_rejected_from_hof():
 
     prog_a = make_prog("const_1")
     preds_a = np.array([[1.0, 2.0], [3.0, 4.0]])
-    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, preds_a))
+    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, preds_a), 0)
     assert len(hof._hof_programs_data) == 1
 
     prog_b = make_prog("const_neg_1")
     preds_b = preds_a * 2.0  # perfectly correlated with preds_a
-    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, preds_b))
+    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, preds_b), 0)
 
     assert len(hof._hof_programs_data) == 1
     assert len(hof._hof_rank_pred_matrix) == 1


### PR DESCRIPTION
## Summary
- store generation in Hall of Fame entries
- display generation column when printing the HOF table
- pass generation index to `add_program_to_hof`
- adjust tests for the new function signature

## Testing
- `ruff check evolution_components/hall_of_fame_manager.py evolve_alphas.py tests/test_hof.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68431de552fc832e91014d7234965db3