### PR TITLE
Bias random ops toward vectors

### DIFF
--- a/alpha_framework/program_logic_generation.py
+++ b/alpha_framework/program_logic_generation.py
@@ -3,6 +3,10 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 import numpy as np
 
 from .alpha_framework_types import TypeId, OP_REGISTRY, FINAL_PREDICTION_VECTOR_NAME
+
+# Probability that a newly added op must output a vector.  Can be
+# overridden by callers (e.g. `evolve_alphas`) before program creation.
+VECTOR_OPS_BIAS = 0.0
 from .alpha_framework_op import Op
 
 # Per-stage limits from the paper
@@ -60,6 +64,10 @@ def generate_random_program_logic(
             for op_name, spec in OP_REGISTRY.items():
                 if op_name == "assign_vector" and is_predict and k != how_many - 1:
                     continue          # reserve assign_vector for emergency only
+
+                # ─── bias towards ops that output vectors ───
+                if rng.random() < VECTOR_OPS_BIAS and spec.out_type != "vector":
+                    continue
 
                 inputs_for_spec: List[List[str]] = []
                 ok = True

--- a/alpha_framework/program_logic_variation.py
+++ b/alpha_framework/program_logic_variation.py
@@ -10,6 +10,10 @@ from .alpha_framework_types import (
     SCALAR_FEATURE_NAMES,
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
 )
+
+# Probability that a newly added op must output a vector.  Callers may
+# override this (see `evolve_alphas`).
+VECTOR_OPS_BIAS = 0.0
 from .alpha_framework_op import Op
 from .program_logic_generation import (
     MAX_SETUP_OPS,
@@ -76,6 +80,10 @@ def mutate_program_logic(
                 pass
             elif op_n == "assign_vector" and chosen_block_name == "predict" and insertion_idx < len(chosen_block_ops_list):
                  continue
+
+            # ─── bias towards ops that output vectors ───
+            if rng.random() < VECTOR_OPS_BIAS and op_s.out_type != "vector":
+                continue
 
             formable = True
             temp_inputs_sources = []

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -7,6 +7,8 @@ import numpy as np
 import logging
 
 from alpha_framework import AlphaProgram, TypeId, CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
+import alpha_framework.program_logic_generation as plg
+import alpha_framework.program_logic_variation as plv
 from evolution_components import (
     initialize_data, 
     evaluate_program, 
@@ -68,6 +70,11 @@ INITIAL_STATE_VARS: Dict[str, TypeId] = {
     "prev_s1_vec": "vector",
     "rolling_mean_custom": "vector"
 }
+
+# ─── bias random generation and mutation towards vector-returning ops ───
+VECTOR_OPS_BIAS = 0.3
+plg.VECTOR_OPS_BIAS = VECTOR_OPS_BIAS
+plv.VECTOR_OPS_BIAS = VECTOR_OPS_BIAS
 
 def _random_prog(cfg: EvoConfig) -> AlphaProgram: # Signature changed
     return AlphaProgram.random_program(


### PR DESCRIPTION
## Summary
- introduce `VECTOR_OPS_BIAS` and set it in `evolve_alphas`
- use this bias when creating random programs and mutating programs so that
  some added ops must output vectors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847199af0dc832eab81f95f51ade4f4