### PR TITLE
Set crypto annualization defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Section 4.1 of the reproduction guide:
 * scalar/vector/matrix operand limits **10/16/4**
 * evaluation cache size **128**
 * correlation cutoff for Hall of Fame entries **15 %**
+* annualization factor **365 * 6** (default for 4-hour crypto bars)
 
 ## Data handling
 

--- a/backtesting_components/core_logic.py
+++ b/backtesting_components/core_logic.py
@@ -68,7 +68,7 @@ def backtest_cross_sectional_alpha(
     scalar_feature_names: List[str], # Pass these from calling script
     cross_sectional_feature_vector_names: List[str], # Pass these
     debug_prints: bool = False, # For optional debug prints
-    annualization_factor: float = (252 * 6) # Default for 4H bars, 252 days
+    annualization_factor: float = (365 * 6) # Default for 4H bars, 365 days (crypto)
 ) -> Dict[str, Any]:
     
     program_state: Dict[str, Any] = prog.new_state()

--- a/config.py
+++ b/config.py
@@ -106,7 +106,8 @@ class BacktestConfig(DataConfig):
     fee: float = 1.0                      # round-trip commission (bps)
     hold: int = 1                         # holding period (bars)
     scale: str = "zscore"
-    annualization_factor: float = 252 * 6
+    # For 4 hour bars on 24/7 crypto data use 365 days × 6 bars/day
+    annualization_factor: float = 365 * 6
     seed: int = 42
 
 


### PR DESCRIPTION
## Summary
- adjust the default `annualization_factor` for 24/7 crypto data
- update documentation with new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486b995e24832e84dc635a045c8d06