### PR TITLE
Update parsimony penalty default

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,7 +77,7 @@ class EvolutionConfig(DataConfig):
     max_scalar_operands: int = 10
     max_vector_operands: int = 16
     max_matrix_operands: int = 4
-    parsimony_penalty: float = 0.0001
+    parsimony_penalty: float = 0.002
     corr_penalty_w: float = 0.35
     corr_cutoff: float = 0.15
     keep_dupes_in_hof: bool = False

--- a/scripts/run_pipeline_all_args.sh
+++ b/scripts/run_pipeline_all_args.sh
@@ -13,7 +13,7 @@ uv run run_pipeline.py 15 \
   --max_scalar_operands 10 \
   --max_vector_operands 16 \
   --max_matrix_operands 4 \
-  --parsimony_penalty 0.0001 \
+  --parsimony_penalty 0.002 \
   --corr_penalty_w 0.25 \
   --corr_cutoff 0.15 \
   --xs_flat_guard 0.02 \


### PR DESCRIPTION
## Summary
- bump `EvolutionConfig.parsimony_penalty` default to 0.002
- propagate new penalty through pipeline script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684873a9b624832ea5601f0dc74446be