### PR TITLE
Add Sharpe proxy metric to evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Section 4.1 of the reproduction guide:
 * setup, predict and update operation limits **21/21/45**
 * scalar/vector/matrix operand limits **10/16/4**
 * evaluation cache size **128**
+* Sharpe proxy weight **0.0** (combines with mean IC when scoring)
 * correlation cutoff for Hall of Fame entries **15 %**
 * annualization factor **365 * 6** (default for 4-hour crypto bars)
 

--- a/config.py
+++ b/config.py
@@ -89,6 +89,8 @@ class EvolutionConfig(DataConfig):
     early_abort_xs: float = 5e-2
     early_abort_t: float = 5e-2
     scale: str = "zscore"
+    # weight for combining Sharpe proxy with mean IC when scoring
+    sharpe_proxy_w: float = 0.0
 
     # evaluation cache
     eval_cache_size: int = 128

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -51,7 +51,8 @@ def _sync_evolution_configs_from_config(cfg: EvoConfig): # Renamed and signature
         early_abort_bars=cfg.early_abort_bars,
         early_abort_xs=cfg.early_abort_xs,
         early_abort_t=cfg.early_abort_t,
-        scale_method=cfg.scale
+        scale_method=cfg.scale,
+        sharpe_proxy_weight=cfg.sharpe_proxy_w
     )
     initialize_hof(
         max_size=cfg.hof_size,

--- a/tests/test_hof.py
+++ b/tests/test_hof.py
@@ -16,12 +16,12 @@ def test_high_corr_program_rejected_from_hof():
 
     prog_a = make_prog("const_1")
     preds_a = np.array([[1.0, 2.0], [3.0, 4.0]])
-    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, preds_a), 0)
+    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, 0.0, preds_a), 0)
     assert len(hof._hof_programs_data) == 1
 
     prog_b = make_prog("const_neg_1")
     preds_b = preds_a * 2.0  # perfectly correlated with preds_a
-    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, preds_b), 0)
+    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, 0.0, preds_b), 0)
 
     assert len(hof._hof_programs_data) == 1
     assert len(hof._hof_rank_pred_matrix) == 1


### PR DESCRIPTION
## Summary
- compute a Sharpe-like proxy during evaluation
- include the proxy in `EvalResult`
- combine mean IC with weighted Sharpe proxy when scoring
- expose the weight via `EvolutionConfig`
- document the new config option
- test that the Sharpe weight affects program fitness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487418e8e0832e9f9f2d54860ea17c