### PR TITLE
Compute Sharpe proxy in evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Section 4.1 of the reproduction guide:
 * scalar/vector/matrix operand limits **10/16/4**
 * evaluation cache size **128**
 * correlation cutoff for Hall of Fame entries **15 %**
+* Sharpe proxy weight **0**
 * annualization factor **365 * 6** (default for 4-hour crypto bars)
 
 ## Data handling

--- a/config.py
+++ b/config.py
@@ -80,6 +80,7 @@ class EvolutionConfig(DataConfig):
     parsimony_penalty: float = 0.002
     corr_penalty_w: float = 0.35
     corr_cutoff: float = 0.15
+    sharpe_proxy_w: float = 0.0
     keep_dupes_in_hof: bool = False
 
     # evaluation specifics

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -52,7 +52,8 @@ def _sync_evolution_configs_from_config(cfg: EvoConfig): # Renamed and signature
         early_abort_xs=cfg.early_abort_xs,
         early_abort_t=cfg.early_abort_t,
         flat_bar_threshold=cfg.flat_bar_threshold,
-        scale_method=cfg.scale
+        scale_method=cfg.scale,
+        sharpe_proxy_weight=cfg.sharpe_proxy_w
     )
     initialize_hof(
         max_size=cfg.hof_size,

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -55,6 +55,7 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig, argparse.Namespace]:
     p.add_argument("--parsimony_penalty",  type=float, default=argparse.SUPPRESS)
     p.add_argument("--corr_penalty_w",     type=float, default=argparse.SUPPRESS)
     p.add_argument("--corr_cutoff",        type=float, default=argparse.SUPPRESS)
+    p.add_argument("--sharpe_proxy_w",     type=float, default=argparse.SUPPRESS)
     p.add_argument("--keep_dupes_in_hof", action="store_true",
                    default=argparse.SUPPRESS)
     p.add_argument("--xs_flat_guard",      type=float, default=argparse.SUPPRESS)

--- a/tests/test_evaluation_logic.py
+++ b/tests/test_evaluation_logic.py
@@ -434,3 +434,67 @@ def test_feature_vector_check_failure():
     assert res.fitness == -float("inf")
     assert res.processed_predictions is None
     assert dh.calls == 0
+
+
+class SharpeDH:
+    def __init__(self):
+        self.index = pd.RangeIndex(4)
+        self.dfs = OrderedDict({
+            "A": pd.DataFrame({"opens": [1, 2, 4, 7], "ret_fwd": [0.1, 0.5, 0.1, 0.4]}, index=self.index),
+            "B": pd.DataFrame({"opens": [2, 1, 3, 5], "ret_fwd": [0.2, -0.1, 0.3, 0.6]}, index=self.index),
+        })
+
+    def get_aligned_dfs(self):
+        return self.dfs
+
+    def get_common_time_index(self):
+        return self.index
+
+    def get_stock_symbols(self):
+        return list(self.dfs.keys())
+
+    def get_n_stocks(self):
+        return len(self.dfs)
+
+    def get_eval_lag(self):
+        return 1
+
+    def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
+        return np.arange(len(self.dfs))
+
+
+def test_sharpe_proxy_weight_alters_fitness():
+    prog = build_simple_program("sp")
+    dh = SharpeDH()
+    hof = DummyHOF()
+    configure_evaluation(
+        parsimony_penalty=0.002,
+        max_ops=32,
+        xs_flatness_guard=5e-3,
+        temporal_flatness_guard=5e-3,
+        early_abort_bars=20,
+        early_abort_xs=0.05,
+        early_abort_t=0.05,
+        flat_bar_threshold=0.25,
+        scale_method="zscore",
+        sharpe_proxy_weight=0.0,
+    )
+    initialize_evaluation_cache(max_size=2)
+    res0 = evaluate_program(prog, dh, hof, {})
+
+    configure_evaluation(
+        parsimony_penalty=0.002,
+        max_ops=32,
+        xs_flatness_guard=5e-3,
+        temporal_flatness_guard=5e-3,
+        early_abort_bars=20,
+        early_abort_xs=0.05,
+        early_abort_t=0.05,
+        flat_bar_threshold=0.25,
+        scale_method="zscore",
+        sharpe_proxy_weight=1.0,
+    )
+    initialize_evaluation_cache(max_size=2)
+    res1 = evaluate_program(prog, dh, hof, {})
+
+    assert res1.fitness == pytest.approx(res0.fitness + res1.sharpe_proxy)

--- a/tests/test_hof.py
+++ b/tests/test_hof.py
@@ -16,12 +16,12 @@ def test_high_corr_program_rejected_from_hof():
 
     prog_a = make_prog("const_1")
     preds_a = np.array([[1.0, 2.0], [3.0, 4.0]])
-    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, preds_a), 0)
+    hof.add_program_to_hof(prog_a, EvalResult(1.0, 0.0, 0.0, 0.0, 0.0, preds_a), 0)
     assert len(hof._hof_programs_data) == 1
 
     prog_b = make_prog("const_neg_1")
     preds_b = preds_a * 2.0  # perfectly correlated with preds_a
-    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, preds_b), 0)
+    hof.add_program_to_hof(prog_b, EvalResult(0.9, 0.0, 0.0, 0.0, 0.0, preds_b), 0)
 
     assert len(hof._hof_programs_data) == 1
     assert len(hof._hof_rank_pred_matrix) == 1


### PR DESCRIPTION
## Summary
- extend `EvalResult` with `sharpe_proxy`
- combine mean IC with Sharpe proxy during scoring
- expose `sharpe_proxy_w` coefficient via `EvolutionConfig`
- propagate CLI and config plumbing
- document new hyperparameter in README
- add regression test for the new weight

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68488f53410c832ebefee75f41d8a94b