### PR TITLE
Handle no trade cases and report errors

### DIFF
--- a/backtest_evolved_alphas.py
+++ b/backtest_evolved_alphas.py
@@ -148,7 +148,7 @@ def main() -> None:
         df = pd.DataFrame(results).sort_values("Sharpe", ascending=False)
         summary = Path(cli.outdir) / f"backtest_summary_top{cfg.top_to_backtest}.csv"
         df.to_csv(summary, index=False, float_format="%.4f")
-        print(df.drop(columns=["Program", "Error"], errors="ignore").to_string(index=False))
+        print(df.drop(columns=["Program"], errors="ignore").to_string(index=False))
         print(f"\nBack-test summary written → {summary}")
 
 

--- a/backtesting_components/core_logic.py
+++ b/backtesting_components/core_logic.py
@@ -168,6 +168,17 @@ def backtest_cross_sectional_alpha(
     abs_pos_diff_sum = np.sum(np.abs(pos_diff), axis=1)
     transaction_costs = (fee_bps * 1e-4) * abs_pos_diff_sum
     daily_portfolio_returns_net = daily_portfolio_returns - transaction_costs
+
+    if not np.any(actual_positions) or not np.any(daily_portfolio_returns_net):
+        return {
+            "Sharpe": 0.0,
+            "AnnReturn": 0.0,
+            "AnnVol": 0.0,
+            "MaxDD": 0.0,
+            "Turnover": 0.0,
+            "Bars": len(daily_portfolio_returns_net),
+            "Error": "No trades executed",
+        }
     
     if debug_prints and len(daily_portfolio_returns_net) > 0:
         mean_ret_calc = np.mean(daily_portfolio_returns_net)

--- a/tests/test_no_trades.py
+++ b/tests/test_no_trades.py
@@ -1,0 +1,37 @@
+from alpha_framework import (
+    AlphaProgram,
+    Op,
+    FINAL_PREDICTION_VECTOR_NAME,
+    SCALAR_FEATURE_NAMES,
+    CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+)
+from backtesting_components.data_handling_bt import load_and_align_data_for_backtest
+from backtesting_components.core_logic import backtest_cross_sectional_alpha
+
+
+def test_constant_signal_no_trades():
+    aligned, index, symbols = load_and_align_data_for_backtest(
+        "tests/data/good", "common_1200", 4
+    )
+    prog = AlphaProgram(
+        predict_ops=[
+            Op("zero", "sub", ("const_1", "const_1")),
+            Op("zeros", "vec_mul_scalar", ("opens_t", "zero")),
+            Op(FINAL_PREDICTION_VECTOR_NAME, "vec_add_scalar", ("zeros", "const_1")),
+        ]
+    )
+    metrics = backtest_cross_sectional_alpha(
+        prog=prog,
+        aligned_dfs=aligned,
+        common_time_index=index,
+        stock_symbols=symbols,
+        n_stocks=len(symbols),
+        fee_bps=1.0,
+        lag=1,
+        hold=1,
+        scale_method="zscore",
+        initial_state_vars_config={"prev_s1_vec": "vector"},
+        scalar_feature_names=SCALAR_FEATURE_NAMES,
+        cross_sectional_feature_vector_names=CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+    )
+    assert metrics.get("Error") == "No trades executed"


### PR DESCRIPTION
## Summary
- detect no-trade situations in the backtester and return an error message
- show the error column in backtest summaries
- test that constant signal programs surface the error

## Testing
- `pytest -q`
- `pytest tests/test_no_trades.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6848d7420bf0832ea1a7d2cdd8715428