### PR TITLE
Add ret1d and range_rel features

### DIFF
--- a/UI_alphas_lab/constants.ts
+++ b/UI_alphas_lab/constants.ts
@@ -12,7 +12,8 @@ export const OP_REGISTRY_KEYS: string[] = [
 export const CROSS_SECTIONAL_FEATURE_VECTOR_NAMES_CONST: string[] = [
     "opens_t", "highs_t", "lows_t", "closes_t", "ranges_t",
     "ma5_t", "ma10_t", "ma20_t", "ma30_t",
-    "vol5_t", "vol10_t", "vol20_t", "vol30_t"
+    "vol5_t", "vol10_t", "vol20_t", "vol30_t",
+    "ret1d_t", "range_rel_t"
 ];
 
 export const SCALAR_FEATURE_NAMES_CONST: string[] = ["const_1", "const_neg_1"];

--- a/alpha_framework/alpha_framework_types.py
+++ b/alpha_framework/alpha_framework_types.py
@@ -12,6 +12,7 @@ CROSS_SECTIONAL_FEATURE_VECTOR_NAMES = [
     "opens_t", "highs_t", "lows_t", "closes_t", "ranges_t",
     "ma5_t", "ma10_t", "ma20_t", "ma30_t",
     "vol5_t", "vol10_t", "vol20_t", "vol30_t",
+    "ret1d_t", "range_rel_t",
     "sector_id_vector",
 ]
 SCALAR_FEATURE_NAMES = ["const_1", "const_neg_1"]

--- a/backtesting_components/data_handling_bt.py
+++ b/backtesting_components/data_handling_bt.py
@@ -14,6 +14,8 @@ def _rolling_features_individual_df_bt(df: pd.DataFrame) -> pd.DataFrame:
         df[f"ma{w}"] = df["close"].rolling(w, min_periods=1).mean()
         df[f"vol{w}"] = df["close"].rolling(w, min_periods=1).std(ddof=0)
     df["range"] = df["high"] - df["low"]
+    df["ret_1d"] = df["close"].pct_change().fillna(0.0)
+    df["range_rel"] = (df["high"] - df["low"]) / df["close"]
     df["ret_fwd"] = df["close"].pct_change(periods=1).shift(-1)
     return df
 

--- a/evolution_components/data_handling.py
+++ b/evolution_components/data_handling.py
@@ -23,6 +23,8 @@ def _rolling_features_individual_df(df: pd.DataFrame) -> pd.DataFrame:
         df[f"ma{w}"] = df["close"].rolling(w, min_periods=1).mean()
         df[f"vol{w}"] = df["close"].rolling(w, min_periods=1).std(ddof=0)
     df["range"] = df["high"] - df["low"]
+    df["ret_1d"] = df["close"].pct_change().fillna(0.0)
+    df["range_rel"] = (df["high"] - df["low"]) / df["close"]
     df["ret_fwd"] = df["close"].pct_change(periods=1).shift(-1) # Shift by -1 for ret_fwd
     return df
 

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -22,6 +22,8 @@ def test_load_and_align_internal_success():
     assert len(common_idx) == 4
     for df in aligned.values():
         assert list(df.index) == list(common_idx)
+        assert "ret_1d" in df.columns
+        assert "range_rel" in df.columns
 
 
 def test_load_and_align_for_backtest_success():
@@ -32,6 +34,8 @@ def test_load_and_align_for_backtest_success():
     assert len(common_idx) == 4
     for df in aligned.values():
         assert list(df.index) == list(common_idx)
+        assert "ret_1d" in df.columns
+        assert "range_rel" in df.columns
 
 
 def test_internal_missing_columns_raises():


### PR DESCRIPTION
## Summary
- compute `ret_1d` and `range_rel` for each symbol in data loaders
- include the new feature vector names in the framework and UI constants
- test data loaders to ensure new columns exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684976cb4ef0832ebecda131ce9997a0