### PR TITLE
Improve README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,19 @@ If `uv` is unavailable you can replace `uv` with `python` in the commands.
 
 ## Running tests
 
-Before running tests ensure the Python dependencies are installed.  You can do
-this directly or via the helper script:
+Before running `pytest` you **must** install the project's dependencies:
 
 ```bash
-pip install -r requirements.txt  # or sh scripts/setup_env.sh
+pip install -r requirements.txt
 ```
 
-Once the environment is ready, run pytest.  The `-q` flag gives a concise
+If you prefer, you can run the helper script instead:
+
+```bash
+sh scripts/setup_env.sh
+```
+
+Once the environment is ready, run `pytest`.  The `-q` flag gives a concise
 summary and should complete without failures:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that dependencies **must** be installed before running `pytest`
- mention `scripts/setup_env.sh` as an alternative setup method

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849798c3e84832e9be6ec4f151de8e6