### PR TITLE
Add helper for feature extraction

### DIFF
--- a/evolution_components/evaluation_logic.py
+++ b/evolution_components/evaluation_logic.py
@@ -263,27 +263,9 @@ def evaluate_program(
     for t_idx in range(num_evaluation_steps):
         timestamp = common_time_index[t_idx]
 
-        features_at_t: Dict[str, Any] = {}
-        for feat_name_template in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES:
-            if feat_name_template == "sector_id_vector":
-                features_at_t[feat_name_template] = sector_groups_vec
-                continue
-            col_name = feat_name_template.replace('_t', '')
-            try:
-                feat_vec = np.array([aligned_dfs[sym].loc[timestamp, col_name] for sym in stock_symbols], dtype=float)
-                features_at_t[feat_name_template] = np.nan_to_num(feat_vec, nan=0.0, posinf=0.0, neginf=0.0)  # Clean at source
-            except KeyError:
-                features_at_t[feat_name_template] = np.zeros(n_stocks, dtype=float)
-            except Exception:  # Broad exception during feature gathering
-                features_at_t[feat_name_template] = np.zeros(n_stocks, dtype=float)
-
-
-        for sc_name in SCALAR_FEATURE_NAMES:
-            if sc_name == "const_1":
-                features_at_t[sc_name] = 1.0
-            elif sc_name == "const_neg_1":
-                features_at_t[sc_name] = -1.0
-            # Add other scalar features if any
+        features_at_t = dh_module.get_features_at_time(
+            timestamp, aligned_dfs, stock_symbols, sector_groups_vec
+        )
 
         try:
             # prog.eval uses n_stocks for internal vector shaping/broadcasting.

--- a/tests/test_evaluation_logic.py
+++ b/tests/test_evaluation_logic.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from collections import OrderedDict
 import pytest
+from evolution_components import data_handling
 
 from evolution_components.evaluation_logic import (
     _safe_corr_eval,
@@ -102,6 +103,9 @@ def test_evaluate_program_basic(monkeypatch):
         def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
             return np.arange(len(self.dfs))
 
+        def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+            return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
+
     dh = DummyDH()
 
     class DummyHOF:
@@ -162,14 +166,9 @@ class CountingDH:
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
 
-    def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
-        return np.arange(len(self.dfs))
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
-    def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
-        return np.arange(len(self.dfs))
-
-    def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
-        return np.arange(len(self.dfs))
 
 
 class DummyHOF:
@@ -239,6 +238,8 @@ class FlatDH:
 
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
 
 class XSCrossFlatDH:
@@ -267,6 +268,8 @@ class XSCrossFlatDH:
 
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
 
 class TemporalFlatDH:
@@ -295,6 +298,8 @@ class TemporalFlatDH:
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
 
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
 class PartialFlatBarsDH:
     def __init__(self):
@@ -321,6 +326,8 @@ class PartialFlatBarsDH:
 
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
 
 class ProcessedFlatDH:
@@ -349,6 +356,8 @@ class ProcessedFlatDH:
 
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
 
 def test_early_abort_triggered():
@@ -571,6 +580,8 @@ class SharpeDH:
 
     def get_sector_groups(self, symbols=None, mapping=None, cfg=None):
         return np.arange(len(self.dfs))
+    def get_features_at_time(self, timestamp, aligned_dfs, stock_symbols, sector_groups_vec):
+        return data_handling.get_features_at_time(timestamp, aligned_dfs, stock_symbols, sector_groups_vec)
 
 
 def test_sharpe_proxy_weight_alters_fitness():


### PR DESCRIPTION
## Summary
- implement `get_features_at_time` in `evolution_components.data_handling`
- reuse helper inside evaluation and backtesting logic
- update test helpers to expose `get_features_at_time`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684979752d04832eafdac829e454b8b8