### PR TITLE
Clean up unused constants and imports

### DIFF
--- a/alpha_framework/alpha_framework_program.py
+++ b/alpha_framework/alpha_framework_program.py
@@ -11,9 +11,8 @@ import numpy as np
 from .alpha_framework_types import (
     TypeId,
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
-    SCALAR_FEATURE_NAMES,
     FINAL_PREDICTION_VECTOR_NAME,
-    OP_REGISTRY # Required for OpSpec access
+    OP_REGISTRY,  # Required for OpSpec access
 )
 from .alpha_framework_op import Op
 from . import program_logic_generation
@@ -142,8 +141,7 @@ class AlphaProgram:
     @staticmethod
     def _get_default_feature_vars() -> Dict[str, TypeId]:
         default_vars = {name: "vector" for name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES}
-        # Do not include constant scalar features by default.  They are still
-        # available via SCALAR_FEATURE_NAMES if callers need them explicitly.
+        # Do not include constant scalar features by default.
         return default_vars
 
     def new_state(self) -> Dict[str, Union[np.ndarray, float]]:

--- a/alpha_framework/program_logic_generation.py
+++ b/alpha_framework/program_logic_generation.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, List, Optional
 import numpy as np
 
+from .alpha_framework_op import Op
 from .alpha_framework_types import TypeId, OP_REGISTRY, FINAL_PREDICTION_VECTOR_NAME
 
 # Probability that a newly added op must output a vector.  Can be
 # overridden by callers (e.g. `evolve_alphas`) before program creation.
 VECTOR_OPS_BIAS = 0.0
-from .alpha_framework_op import Op
 
 # Per-stage limits from the paper
 MAX_SETUP_OPS = 21

--- a/alpha_framework/program_logic_variation.py
+++ b/alpha_framework/program_logic_variation.py
@@ -3,23 +3,23 @@ from typing import TYPE_CHECKING, Dict, Optional
 import numpy as np
 import copy # For crossover, specifically deepcopy of other's predict_ops
 
-from .alpha_framework_types import (
-    TypeId,
-    OP_REGISTRY,
-    FINAL_PREDICTION_VECTOR_NAME,
-    SCALAR_FEATURE_NAMES,
-    CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
-)
-
-# Probability that a newly added op must output a vector.  Callers may
-# override this (see `evolve_alphas`).
-VECTOR_OPS_BIAS = 0.0
 from .alpha_framework_op import Op
 from .program_logic_generation import (
     MAX_SETUP_OPS,
     MAX_PREDICT_OPS,
     MAX_UPDATE_OPS,
 )
+from .alpha_framework_types import (
+    TypeId,
+    OP_REGISTRY,
+    FINAL_PREDICTION_VECTOR_NAME,
+    SCALAR_FEATURE_NAMES,
+    CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+)
+
+# Probability that a newly added op must output a vector.  Callers may
+# override this (see `evolve_alphas`).
+VECTOR_OPS_BIAS = 0.0
 
 
 if TYPE_CHECKING:

--- a/evolution_components/evaluation_logic.py
+++ b/evolution_components/evaluation_logic.py
@@ -11,10 +11,9 @@ if TYPE_CHECKING:
     from evolution_components import data_handling # To access data
     from evolution_components import hall_of_fame_manager as hof_manager # To get HOF penalty
 
-from alpha_framework.alpha_framework_types import ( # Ensure these are correct based on where AlphaProgram is defined
+from alpha_framework.alpha_framework_types import (  # Ensure these are correct based on where AlphaProgram is defined
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
-    SCALAR_FEATURE_NAMES,
-    FINAL_PREDICTION_VECTOR_NAME
+    FINAL_PREDICTION_VECTOR_NAME,
 )
 
 

--- a/tests/test_evolve_process.py
+++ b/tests/test_evolve_process.py
@@ -1,5 +1,3 @@
-import pytest
-
 from config import EvolutionConfig
 from alpha_framework import AlphaProgram, Op, FINAL_PREDICTION_VECTOR_NAME
 import evolve_alphas


### PR DESCRIPTION
## Summary
- drop unused `SCALAR_FEATURE_NAMES` imports
- clean up comment about scalar features
- place Op and generator imports at the top of modules
- remove unused `pytest` in tests
- verify code style with `ruff`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684982546988832eb0849925b31e103b