### PR TITLE
Add long_short_n to backtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ This convenience script mirrors all defaults from `config.py` so you can easily
 edit any knob.
 
 The `--debug_prints` flag forwards verbose output to the back-tester.
+Use `--long_short_n` to trade only the top/bottom N ranked symbols in each
+period.  Set it to `0` (default) to use all available symbols.
 
 Logging can be controlled globally via `--log-level` and `--log-file`.  The
 `--quiet` and `--debug_prints` flags lower or raise the log verbosity when
@@ -108,6 +110,7 @@ Section 4.1 of the reproduction guide:
 * correlation cutoff for Hall of Fame entries **15 %**
 * Sharpe proxy weight **0**
 * annualization factor **365 * 6** (default for 4-hour crypto bars)
+* long/short universe size **0** (use all symbols)
 
 ## Data handling
 

--- a/backtest_evolved_alphas.py
+++ b/backtest_evolved_alphas.py
@@ -54,6 +54,8 @@ def parse_args() -> tuple[BacktestConfig, argparse.Namespace]:
     p.add_argument("--data",              dest="data_dir",            default=argparse.SUPPRESS)
     p.add_argument("--fee",               type=float,                 default=argparse.SUPPRESS)
     p.add_argument("--hold",              type=int,                   default=argparse.SUPPRESS)
+    p.add_argument("--long_short_n",      type=int,                   default=argparse.SUPPRESS,
+                   help="trade only top/bottom N symbols")
     p.add_argument("--annualization_factor", type=float, default=argparse.SUPPRESS)
     p.add_argument("--scale",             choices=["zscore", "rank", "sign"],
                                                                   default=argparse.SUPPRESS)
@@ -119,6 +121,7 @@ def main() -> None:
             fee_bps=cfg.fee,
             lag=cfg.eval_lag,
             hold=cfg.hold,
+            long_short_n=cfg.long_short_n,
             scale_method=cfg.scale,
             initial_state_vars_config={"prev_s1_vec": "vector"},
             scalar_feature_names=SCALAR_FEATURE_NAMES,

--- a/backtesting_components/core_logic.py
+++ b/backtesting_components/core_logic.py
@@ -66,6 +66,7 @@ def backtest_cross_sectional_alpha(
     lag: int, 
     hold: int, 
     scale_method: str,
+    long_short_n: int,
     initial_state_vars_config: Dict[str, str], # e.g. {"prev_s1_vec": "vector"}
     scalar_feature_names: List[str], # Pass these from calling script
     cross_sectional_feature_vector_names: List[str], # Pass these
@@ -121,6 +122,15 @@ def backtest_cross_sectional_alpha(
     target_positions_matrix = np.zeros_like(signal_matrix)
     for t in range(signal_matrix.shape[0]):
         scaled_signal_t = _scale_signal_cross_sectionally(signal_matrix[t, :], scale_method)
+        if long_short_n > 0:
+            k = min(long_short_n, n_stocks // 2)
+            order = np.argsort(scaled_signal_t)
+            long_idx = order[-k:]
+            short_idx = order[:k]
+            ls_vector = np.zeros_like(scaled_signal_t)
+            ls_vector[long_idx] = 1.0
+            ls_vector[short_idx] = -1.0
+            scaled_signal_t = ls_vector
         mean_signal_t = np.mean(scaled_signal_t)
         centered_signal_t = scaled_signal_t - mean_signal_t
         sum_abs_centered_signal = np.sum(np.abs(centered_signal_t))

--- a/config.py
+++ b/config.py
@@ -108,6 +108,7 @@ class BacktestConfig(DataConfig):
     fee: float = 1.0                      # round-trip commission (bps)
     hold: int = 1                         # holding period (bars)
     scale: str = "zscore"
+    long_short_n: int = 0                 # 0 → use all symbols
     # For 4 hour bars on 24/7 crypto data use 365 days × 6 bars/day
     annualization_factor: float = 365 * 6
     seed: int = 42

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -86,6 +86,7 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig, argparse.Namespace]:
 
     p.add_argument("--fee",                            type=float, default=argparse.SUPPRESS)
     p.add_argument("--hold",                           type=int,   default=argparse.SUPPRESS)
+    p.add_argument("--long_short_n",                   type=int,   default=argparse.SUPPRESS)
     p.add_argument("--annualization_factor", type=float, default=argparse.SUPPRESS)
     p.add_argument("--debug_prints", action="store_true")
     p.add_argument("--run_baselines", action="store_true",
@@ -201,6 +202,7 @@ def main() -> None:
         "--top",   str(bt_cfg.top_to_backtest),
         "--fee",   str(bt_cfg.fee),
         "--hold",  str(bt_cfg.hold),
+        "--long_short_n", str(bt_cfg.long_short_n),
         "--annualization_factor", str(bt_cfg.annualization_factor),
         "--scale", bt_cfg.scale,
         "--lag",   str(bt_cfg.eval_lag),

--- a/scripts/recommended_pipeline.sh
+++ b/scripts/recommended_pipeline.sh
@@ -17,6 +17,7 @@ uv run run_pipeline.py 10 \
   --eval_cache_size 128 \
   --corr_cutoff 0.15 \
   --fee 0.5 \
+  --long_short_n 0 \
   --workers 4 \
   --run_baselines \
   --debug_prints

--- a/scripts/run_pipeline_all_args.sh
+++ b/scripts/run_pipeline_all_args.sh
@@ -32,6 +32,7 @@ uv run run_pipeline.py 15 \
   --top 10 \
   --fee 1.0 \
   --hold 1 \
+  --long_short_n 0 \
   --debug_prints \
   --run_baselines \
   # baseline metrics are cached; use --retrain_baselines to refresh

--- a/tests/test_backtest_script.py
+++ b/tests/test_backtest_script.py
@@ -13,6 +13,7 @@ def test_parse_args_defaults(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["backtest_evolved_alphas.py"])
     cfg, ns = parse_args()
     assert cfg.top_to_backtest == 10
+    assert cfg.long_short_n == 0
     assert ns.input == "evolved_top_alphas.pkl"
     assert ns.outdir == "evolved_bt_cs_results"
 
@@ -24,12 +25,14 @@ def test_parse_args_overrides(monkeypatch):
         "--fee", "0.5",
         "--scale", "rank",
         "--data", "data_dir",
+        "--long_short_n", "2",
     ]
     monkeypatch.setattr(sys, "argv", argv)
     cfg, _ = parse_args()
     assert cfg.top_to_backtest == 3
     assert cfg.fee == 0.5
     assert cfg.scale == "rank"
+    assert cfg.long_short_n == 2
 
 
 # -------------------------------------------------------------------

--- a/tests/test_long_short.py
+++ b/tests/test_long_short.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pandas as pd
+from collections import OrderedDict
+import pytest
+
+from backtesting_components.core_logic import backtest_cross_sectional_alpha, _scale_signal_cross_sectionally
+
+class DummyProg:
+    def __init__(self, signals):
+        self.signals = signals
+        self.step = 0
+    def new_state(self):
+        self.step = 0
+        return {}
+    def eval(self, features_at_t, state, n_stocks):
+        res = self.signals[self.step]
+        self.step += 1
+        return res
+    @property
+    def size(self):
+        return 0
+    def to_string(self, max_len=1000):
+        return "dummy"
+
+
+def _build_df(rets, index):
+    cols = [
+        "open",
+        "high",
+        "low",
+        "close",
+        "ma5",
+        "vol5",
+        "ma10",
+        "vol10",
+        "ma20",
+        "vol20",
+        "ma30",
+        "vol30",
+        "range",
+        "ret_1d",
+        "range_rel",
+        "ret_fwd",
+    ]
+    df = pd.DataFrame(0.0, index=index, columns=cols)
+    df["ret_fwd"] = rets
+    return df
+
+
+def manual_backtest(signals, rets, long_short_n):
+    n_steps, n_stocks = signals.shape
+    pos = np.zeros_like(signals)
+    for t in range(n_steps):
+        scaled = _scale_signal_cross_sectionally(signals[t], "zscore")
+        if long_short_n > 0:
+            k = min(long_short_n, n_stocks // 2)
+            order = np.argsort(scaled)
+            ls = np.zeros_like(scaled)
+            ls[order[-k:]] = 1.0
+            ls[order[:k]] = -1.0
+            scaled = ls
+        centered = scaled - np.mean(scaled)
+        sa = np.sum(np.abs(centered))
+        pos[t] = centered / sa if sa > 1e-9 else 0
+    returns = np.sum(pos * rets, axis=1)
+    return pos, returns
+
+
+def test_long_short_n_trades_only_requested_symbols():
+    index = pd.date_range("2020-01-01", periods=5)
+    rets = np.array([
+        [0.01, -0.02, 0.03],
+        [-0.01, 0.02, 0.01],
+        [0.03, 0.01, -0.02],
+        [0.02, -0.01, 0.02],
+        [0.0, 0.0, 0.0],
+    ])
+    aligned = OrderedDict({
+        "AAA": _build_df(rets[:, 0], index),
+        "BBB": _build_df(rets[:, 1], index),
+        "CCC": _build_df(rets[:, 2], index),
+    })
+    signals = np.array([
+        [0.1, 0.2, -0.3],
+        [0.4, -0.1, 0.2],
+        [0.3, 0.5, 0.1],
+        [-0.2, 0.2, 0.0],
+    ])
+    prog = DummyProg(signals)
+    metrics = backtest_cross_sectional_alpha(
+        prog=prog,
+        aligned_dfs=aligned,
+        common_time_index=index,
+        stock_symbols=list(aligned.keys()),
+        n_stocks=3,
+        fee_bps=0.0,
+        lag=0,
+        hold=1,
+        scale_method="zscore",
+        long_short_n=1,
+        initial_state_vars_config={},
+        scalar_feature_names=[],
+        cross_sectional_feature_vector_names=[],
+    )
+    manual_pos, manual_ret = manual_backtest(signals, rets[:-1], 1)
+    assert all(np.count_nonzero(p) == 2 for p in manual_pos)
+    equity = np.cumprod(1 + manual_ret)
+    mean_ret = manual_ret.mean()
+    std_ret = manual_ret.std(ddof=0)
+    sharpe = (mean_ret / (std_ret + 1e-9)) * np.sqrt(365 * 6)
+    assert metrics["Sharpe"] == pytest.approx(sharpe)
+

--- a/tests/test_no_trades.py
+++ b/tests/test_no_trades.py
@@ -29,6 +29,7 @@ def test_constant_signal_no_trades():
         fee_bps=1.0,
         lag=1,
         hold=1,
+        long_short_n=0,
         scale_method="zscore",
         initial_state_vars_config={"prev_s1_vec": "vector"},
         scalar_feature_names=SCALAR_FEATURE_NAMES,

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -11,6 +11,7 @@ def test_parse_args_defaults(monkeypatch):
     # check a couple defaults
     assert evo_cfg.seed == 42
     assert bt_cfg.top_to_backtest == 10
+    assert bt_cfg.long_short_n == 0
     assert ns.debug_prints is False
     assert ns.run_baselines is False
 


### PR DESCRIPTION
## Summary
- extend `BacktestConfig` with `long_short_n`
- support long/short ranking in `backtest_cross_sectional_alpha`
- expose the option via CLI and scripts
- document new flag in README
- test new argument and behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684982cc8e7c832e885456f215b0b6e8