### PR TITLE
Add feature caching

### DIFF
--- a/evolution_components/evaluation_logic.py
+++ b/evolution_components/evaluation_logic.py
@@ -262,9 +262,12 @@ def evaluate_program(
     for t_idx in range(num_evaluation_steps):
         timestamp = common_time_index[t_idx]
 
-        features_at_t = dh_module.get_features_at_time(
-            timestamp, aligned_dfs, stock_symbols, sector_groups_vec
-        )
+        if hasattr(dh_module, "get_features_cached"):
+            features_at_t = dh_module.get_features_cached(timestamp)
+        else:
+            features_at_t = dh_module.get_features_at_time(
+                timestamp, aligned_dfs, stock_symbols, sector_groups_vec
+            )
 
         try:
             # prog.eval uses n_stocks for internal vector shaping/broadcasting.

--- a/evolution_components/hall_of_fame_manager.py
+++ b/evolution_components/hall_of_fame_manager.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, List, Tuple, Dict, Set # Added Set
 from dataclasses import dataclass
 import textwrap # For printing HoF
 import logging
+from . import data_handling
 
 if TYPE_CHECKING:
     from alpha_framework import AlphaProgram
@@ -268,4 +269,5 @@ def clear_hof():
     _hof_fingerprints_set = set()
     _hof_rank_pred_matrix = []
     _hof_corr_fingerprints = []
+    data_handling.clear_feature_cache()
     logging.getLogger(__name__).info("Hall of Fame cleared.")

--- a/tests/test_long_short.py
+++ b/tests/test_long_short.py
@@ -104,7 +104,6 @@ def test_long_short_n_trades_only_requested_symbols():
     )
     manual_pos, manual_ret = manual_backtest(signals, rets[:-1], 1)
     assert all(np.count_nonzero(p) == 2 for p in manual_pos)
-    equity = np.cumprod(1 + manual_ret)
     mean_ret = manual_ret.mean()
     std_ret = manual_ret.std(ddof=0)
     sharpe = (mean_ret / (std_ret + 1e-9)) * np.sqrt(365 * 6)


### PR DESCRIPTION
## Summary
- cache feature vectors in `data_handling` and precompute on data load
- return cached features in evaluation logic when available
- clear feature cache whenever the hall of fame is cleared
- fix ruff style warning in tests

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499551ca2c832eb1e553e180ff9c27