### PR TITLE
Add tests for baseline helper utilities

### DIFF
--- a/tests/test_baseline_helpers.py
+++ b/tests/test_baseline_helpers.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from baselines.rank_lstm import _prepare_sequences, _train_linear, _predict_linear
+from baselines.rsr import _prepare_graph_features
+
+
+# -------------------------------------------------------------------
+# rank_lstm helpers
+# -------------------------------------------------------------------
+def test_prepare_sequences_shapes():
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5]})
+    X, y = _prepare_sequences(df, seq_len=2)
+    assert X.shape == (2, 2)
+    assert y.shape == (2,)
+
+
+def test_train_and_predict_linear():
+    X = np.array([[1.0], [2.0], [3.0], [4.0]])
+    y = np.array([3.0, 5.0, 7.0, 9.0])
+    w = _train_linear(X, y, l2=0.0)
+    assert w == pytest.approx([2.0, 1.0])
+    preds = _predict_linear(w, X)
+    assert np.allclose(preds, y)
+
+
+# -------------------------------------------------------------------
+# rsr helpers
+# -------------------------------------------------------------------
+def test_prepare_graph_features():
+    df = pd.DataFrame({"close": [1, 2, 4, 7]})
+    X = _prepare_graph_features(df, seq_len=2)
+    expected = np.array([[-0.5, 0.5], [-1.0, 1.0]])
+    assert np.allclose(X, expected)


### PR DESCRIPTION
## Summary
- add tests covering helper functions in `rank_lstm` and `rsr`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b7f7f3dc832eba8e7d6e5171eac8