### PR TITLE
Add feature vector scaling

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,6 +48,8 @@ class DataConfig:
     sector_mapping: Dict[str, int] = field(
         default_factory=lambda: DEFAULT_CRYPTO_SECTOR_MAPPING.copy()
     )
+    # How numeric feature vectors are scaled cross-sectionally when extracted
+    feature_scale_method: str = "zscore"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -43,6 +43,7 @@ def _sync_evolution_configs_from_config(cfg: EvoConfig): # Renamed and signature
         min_common_points=cfg.min_common_points,
         eval_lag=cfg.eval_lag
     )
+    dh_module.configure_feature_scaling(cfg.feature_scale_method)
     el_module.configure_evaluation(
         parsimony_penalty=cfg.parsimony_penalty,
         max_ops=cfg.max_ops,


### PR DESCRIPTION
## Summary
- allow configuration of feature scaling via DataConfig
- implement `_scale_feature_vector` in data handling
- scale numeric features inside `get_features_at_time`
- expose configuration hook `configure_feature_scaling`
- test that feature vectors get standardized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b76336dc832ea5cfb36392bfd5cb