### PR TITLE
Switch sector features to mask matrix

### DIFF
--- a/UI_alphas_lab/constants.ts
+++ b/UI_alphas_lab/constants.ts
@@ -16,6 +16,10 @@ export const CROSS_SECTIONAL_FEATURE_VECTOR_NAMES_CONST: string[] = [
     "ret1d_t", "range_rel_t"
 ];
 
+export const CROSS_SECTIONAL_FEATURE_MATRIX_NAMES_CONST: string[] = [
+    "sector_mask_matrix"
+];
+
 export const SCALAR_FEATURE_NAMES_CONST: string[] = ["const_1", "const_neg_1"];
 export const FINAL_PREDICTION_VECTOR_NAME_CONST = "s1_predictions_vector";
 

--- a/alpha_framework/__init__.py
+++ b/alpha_framework/__init__.py
@@ -9,6 +9,7 @@ from .alpha_framework_types import (
     OpSpec,
     OP_REGISTRY,
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+    CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
     SCALAR_FEATURE_NAMES,
     FINAL_PREDICTION_VECTOR_NAME,
     SAFE_MAX
@@ -18,7 +19,7 @@ from .alpha_framework_program import AlphaProgram
 
 __all__ = [
     "TypeId", "OpSpec", "OP_REGISTRY",
-    "CROSS_SECTIONAL_FEATURE_VECTOR_NAMES", "SCALAR_FEATURE_NAMES",
+    "CROSS_SECTIONAL_FEATURE_VECTOR_NAMES", "CROSS_SECTIONAL_FEATURE_MATRIX_NAMES", "SCALAR_FEATURE_NAMES",
     "FINAL_PREDICTION_VECTOR_NAME", "SAFE_MAX",
     "Op", "AlphaProgram", "alpha_framework_operators",
 ]

--- a/alpha_framework/alpha_framework_operators.py
+++ b/alpha_framework/alpha_framework_operators.py
@@ -216,10 +216,14 @@ def _cs_rank(v):
 @register_op("cs_demean", in_types=("vector",), out="vector")
 def _cs_demean(v): return v - (_cs_mean(v) if v.size > 0 else 0.0)
 
-@register_op("relation_rank", in_types=("vector", "vector"), out="vector")
+@register_op("relation_rank", in_types=("vector", "matrix"), out="vector")
 def _relation_rank(v, groups):
     v_arr = np.asarray(v, dtype=float)
-    grp_arr = np.asarray(groups, dtype=int)
+    grp_arr = np.asarray(groups)
+    if grp_arr.ndim == 2:
+        grp_arr = np.argmax(grp_arr, axis=1)
+    else:
+        grp_arr = grp_arr.astype(int)
     result = np.zeros_like(v_arr, dtype=float)
     for g in np.unique(grp_arr):
         mask = grp_arr == g
@@ -233,10 +237,14 @@ def _relation_rank(v, groups):
         result[mask] = (ranks / (vals.size - 1 + 1e-9)) * 2.0 - 1.0
     return result
 
-@register_op("relation_demean", in_types=("vector", "vector"), out="vector")
+@register_op("relation_demean", in_types=("vector", "matrix"), out="vector")
 def _relation_demean(v, groups):
     v_arr = np.asarray(v, dtype=float)
-    grp_arr = np.asarray(groups, dtype=int)
+    grp_arr = np.asarray(groups)
+    if grp_arr.ndim == 2:
+        grp_arr = np.argmax(grp_arr, axis=1)
+    else:
+        grp_arr = grp_arr.astype(int)
     result = np.zeros_like(v_arr, dtype=float)
     for g in np.unique(grp_arr):
         mask = grp_arr == g

--- a/alpha_framework/alpha_framework_types.py
+++ b/alpha_framework/alpha_framework_types.py
@@ -13,7 +13,11 @@ CROSS_SECTIONAL_FEATURE_VECTOR_NAMES = [
     "ma5_t", "ma10_t", "ma20_t", "ma30_t",
     "vol5_t", "vol10_t", "vol20_t", "vol30_t",
     "ret1d_t", "range_rel_t",
-    "sector_id_vector",
+]
+
+# Additional cross‑sectional features that return matrices
+CROSS_SECTIONAL_FEATURE_MATRIX_NAMES = [
+    "sector_mask_matrix",
 ]
 SCALAR_FEATURE_NAMES = ["const_1", "const_neg_1"]
 

--- a/backtest_evolved_alphas.py
+++ b/backtest_evolved_alphas.py
@@ -13,6 +13,7 @@ from config import BacktestConfig                # ← NEW
 from alpha_framework import (
     AlphaProgram,
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+    CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
     SCALAR_FEATURE_NAMES,
     OP_REGISTRY,
 )
@@ -23,7 +24,11 @@ from backtesting_components import (
 
 def _derive_state_vars(prog: AlphaProgram) -> Dict[str, str]:
     """Infer required state variables from the program structure."""
-    feature_vars = set(SCALAR_FEATURE_NAMES) | set(CROSS_SECTIONAL_FEATURE_VECTOR_NAMES)
+    feature_vars = (
+        set(SCALAR_FEATURE_NAMES)
+        | set(CROSS_SECTIONAL_FEATURE_VECTOR_NAMES)
+        | set(CROSS_SECTIONAL_FEATURE_MATRIX_NAMES)
+    )
     defined = set(feature_vars)
     state_vars: Dict[str, str] = {}
 
@@ -148,6 +153,7 @@ def main() -> None:
             initial_state_vars_config=_derive_state_vars(prog),
             scalar_feature_names=SCALAR_FEATURE_NAMES,
             cross_sectional_feature_vector_names=CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+            cross_sectional_feature_matrix_names=CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
             debug_prints=cli.debug_prints,
             annualization_factor=cli.annualization_factor_override
                                    if cli.annualization_factor_override is not None

--- a/evolution_components/evaluation_logic.py
+++ b/evolution_components/evaluation_logic.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from alpha_framework.alpha_framework_types import (  # Ensure these are correct based on where AlphaProgram is defined
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+    CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
     FINAL_PREDICTION_VECTOR_NAME,
 )
 
@@ -153,7 +154,10 @@ def _uses_feature_vector_check(prog: AlphaProgram) -> bool:
             continue
         visited_vars.add(current_var_name)
 
-        if current_var_name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES:
+        if (
+            current_var_name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
+            or current_var_name in CROSS_SECTIONAL_FEATURE_MATRIX_NAMES
+        ):
             return True # Found a dependency on a feature vector
 
         # If current_var_name is an initial state var that might be a vector,
@@ -229,7 +233,7 @@ def evaluate_program(
     n_stocks = dh_module.get_n_stocks()
     eval_lag = dh_module.get_eval_lag() # Get eval_lag from data_handling
 
-    sector_groups_vec = dh_module.get_sector_groups(stock_symbols).astype(float)
+    sector_groups_vec = dh_module.get_sector_groups(stock_symbols)
 
     program_state: Dict[str, Any] = prog.new_state() # AlphaProgram's own new_state
     for s_name, s_type in initial_prog_state_vars_config.items():  # Use passed config

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -6,7 +6,12 @@ from multiprocessing import Pool, cpu_count
 import numpy as np
 import logging
 
-from alpha_framework import AlphaProgram, TypeId, CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
+from alpha_framework import (
+    AlphaProgram,
+    TypeId,
+    CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+    CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
+)
 import alpha_framework.program_logic_generation as plg
 import alpha_framework.program_logic_variation as plv
 from evolution_components import (
@@ -64,7 +69,10 @@ def _sync_evolution_configs_from_config(cfg: EvoConfig): # Renamed and signature
     initialize_evaluation_cache(cfg.eval_cache_size)
 
 
-FEATURE_VARS: Dict[str, TypeId] = {name: "vector" for name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES}
+FEATURE_VARS: Dict[str, TypeId] = {
+    name: "vector" for name in CROSS_SECTIONAL_FEATURE_VECTOR_NAMES
+}
+FEATURE_VARS.update({name: "matrix" for name in CROSS_SECTIONAL_FEATURE_MATRIX_NAMES})
 # Constant scalar features are deliberately excluded to align with the
 # reference paper.  They remain accessible via SCALAR_FEATURE_NAMES if needed.
 

--- a/tests/test_evaluation_logic.py
+++ b/tests/test_evaluation_logic.py
@@ -521,7 +521,8 @@ def test_sector_vector_available():
     dh = SectorDH()
     hof = DummyHOF()
     prog = AlphaProgram(predict_ops=[
-        Op(FINAL_PREDICTION_VECTOR_NAME, "vec_mul_scalar", ("sector_id_vector", "const_1"))
+        Op("sector_one", "get_stock_vector", ("sector_mask_matrix", "const_1")),
+        Op(FINAL_PREDICTION_VECTOR_NAME, "assign_vector", ("sector_one",)),
     ])
     configure_evaluation(
         parsimony_penalty=0.002,

--- a/tests/test_long_short.py
+++ b/tests/test_long_short.py
@@ -101,6 +101,7 @@ def test_long_short_n_trades_only_requested_symbols():
         initial_state_vars_config={},
         scalar_feature_names=[],
         cross_sectional_feature_vector_names=[],
+        cross_sectional_feature_matrix_names=[],
     )
     manual_pos, manual_ret = manual_backtest(signals, rets[:-1], 1)
     assert all(np.count_nonzero(p) == 2 for p in manual_pos)

--- a/tests/test_no_trades.py
+++ b/tests/test_no_trades.py
@@ -4,6 +4,7 @@ from alpha_framework import (
     FINAL_PREDICTION_VECTOR_NAME,
     SCALAR_FEATURE_NAMES,
     CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+    CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
 )
 from backtesting_components.data_handling_bt import load_and_align_data_for_backtest
 from backtesting_components.core_logic import backtest_cross_sectional_alpha
@@ -34,5 +35,6 @@ def test_constant_signal_no_trades():
         initial_state_vars_config={"prev_s1_vec": "vector"},
         scalar_feature_names=SCALAR_FEATURE_NAMES,
         cross_sectional_feature_vector_names=CROSS_SECTIONAL_FEATURE_VECTOR_NAMES,
+        cross_sectional_feature_matrix_names=CROSS_SECTIONAL_FEATURE_MATRIX_NAMES,
     )
     assert metrics.get("Error") == "No trades executed"

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -56,7 +56,10 @@ def test_heaviside_op():
 def test_relation_ops():
     v = np.array([1.0, 2.0, 3.0, 1.0, 2.0, 3.0])
     groups = np.array([0, 0, 0, 1, 1, 1])
-    buf = {"v": v, "g": groups}
+    mask = np.zeros((len(groups), 2))
+    mask[groups == 0, 0] = 1.0
+    mask[groups == 1, 1] = 1.0
+    buf = {"v": v, "g": mask}
     Op("rank_out", "relation_rank", ("v", "g")).execute(buf, n_stocks=6)
     Op("demean_out", "relation_demean", ("v", "g")).execute(buf, n_stocks=6)
     expected_rank = np.array([-1.0, 0.0, 1.0, -1.0, 0.0, 1.0])
@@ -68,7 +71,11 @@ def test_relation_ops():
 def test_relation_ops_realistic_groups():
     v = np.array([10.0, 20.0, 30.0, 100.0, 80.0, 5.0, 15.0, 25.0])
     groups = np.array([1, 1, 1, 2, 2, 3, 3, 3])
-    buf = {"v": v, "g": groups}
+    uniq = np.unique(groups)
+    mask = np.zeros((len(groups), len(uniq)))
+    for idx, g in enumerate(uniq):
+        mask[groups == g, idx] = 1.0
+    buf = {"v": v, "g": mask}
     Op("rank_out", "relation_rank", ("v", "g")).execute(buf, n_stocks=8)
     Op("demean_out", "relation_demean", ("v", "g")).execute(buf, n_stocks=8)
     expected_rank = np.array([-1.0, 0.0, 1.0, 1.0, -1.0, -1.0, 0.0, 1.0])


### PR DESCRIPTION
## Summary
- represent sector info via `sector_mask_matrix`
- add one-hot generator in data handling
- accept sector mask in relation ops
- support matrix features in framework and scripts
- adjust evaluation and backtest tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849b81587d0832ea9402ef86f385f2f