### PR TITLE
Implement operand-type limits for Alpha program generation

### DIFF
--- a/alpha_framework/alpha_framework_program.py
+++ b/alpha_framework/alpha_framework_program.py
@@ -6,6 +6,7 @@ import json
 import textwrap
 from typing import Dict, List, Literal, Optional, Union
 import numpy as np
+import sys
 
 # Imports from other framework modules
 from .alpha_framework_types import (
@@ -104,6 +105,9 @@ class AlphaProgram:
         max_setup_ops: int = program_logic_generation.MAX_SETUP_OPS,
         max_predict_ops: int = program_logic_generation.MAX_PREDICT_OPS,
         max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS,
+        max_scalar_operands: int = sys.maxsize,
+        max_vector_operands: int = sys.maxsize,
+        max_matrix_operands: int = sys.maxsize,
     ) -> "AlphaProgram":
         """Create a random, type-correct program.
 
@@ -133,6 +137,9 @@ class AlphaProgram:
             max_setup_ops,
             max_predict_ops,
             max_update_ops,
+            max_scalar_operands,
+            max_vector_operands,
+            max_matrix_operands,
         )
 
     def copy(self) -> "AlphaProgram":
@@ -153,7 +160,10 @@ class AlphaProgram:
                rng: Optional[np.random.Generator] = None,
                max_setup_ops: int = program_logic_generation.MAX_SETUP_OPS,
                max_predict_ops: int = program_logic_generation.MAX_PREDICT_OPS,
-               max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS) -> "AlphaProgram":
+               max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS,
+               max_scalar_operands: int = sys.maxsize,
+               max_vector_operands: int = sys.maxsize,
+               max_matrix_operands: int = sys.maxsize) -> "AlphaProgram":
         """Return a mutated copy of this program."""
 
         return mutate_program_logic(
@@ -169,6 +179,9 @@ class AlphaProgram:
             max_setup_ops,
             max_predict_ops,
             max_update_ops,
+            max_scalar_operands,
+            max_vector_operands,
+            max_matrix_operands,
         )
 
     def crossover(
@@ -178,6 +191,9 @@ class AlphaProgram:
         max_setup_ops: int = program_logic_generation.MAX_SETUP_OPS,
         max_predict_ops: int = program_logic_generation.MAX_PREDICT_OPS,
         max_update_ops: int = program_logic_generation.MAX_UPDATE_OPS,
+        max_scalar_operands: int = sys.maxsize,
+        max_vector_operands: int = sys.maxsize,
+        max_matrix_operands: int = sys.maxsize,
     ) -> "AlphaProgram":
         """Create offspring from this program and ``other``."""
 
@@ -188,6 +204,9 @@ class AlphaProgram:
             max_setup_ops,
             max_predict_ops,
             max_update_ops,
+            max_scalar_operands,
+            max_vector_operands,
+            max_matrix_operands,
         )
 
     @staticmethod

--- a/evolve_alphas.py
+++ b/evolve_alphas.py
@@ -96,6 +96,9 @@ def _random_prog(cfg: EvoConfig) -> AlphaProgram: # Signature changed
         max_setup_ops=cfg.max_setup_ops,
         max_predict_ops=cfg.max_predict_ops,
         max_update_ops=cfg.max_update_ops,
+        max_scalar_operands=cfg.max_scalar_operands,
+        max_vector_operands=cfg.max_vector_operands,
+        max_matrix_operands=cfg.max_matrix_operands,
     )
 
 def _mutate_prog(p: AlphaProgram, cfg: EvoConfig) -> AlphaProgram: # Signature changed
@@ -106,6 +109,9 @@ def _mutate_prog(p: AlphaProgram, cfg: EvoConfig) -> AlphaProgram: # Signature c
         max_setup_ops=cfg.max_setup_ops,
         max_predict_ops=cfg.max_predict_ops,
         max_update_ops=cfg.max_update_ops,
+        max_scalar_operands=cfg.max_scalar_operands,
+        max_vector_operands=cfg.max_vector_operands,
+        max_matrix_operands=cfg.max_matrix_operands,
     )
 
 def _eval_worker(args) -> Tuple[int, el_module.EvalResult]:


### PR DESCRIPTION
## Summary
- enforce scalar/vector/matrix operation caps during random program generation and mutation
- plumb new limit parameters through AlphaProgram API and evolve helpers
- ensure operand limits honoured in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849be6703f4832e8dfbf7cbf5124391