### PR TITLE
Fix CLI dataclass parsing

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -104,10 +104,13 @@ def parse_args() -> tuple[EvolutionConfig, BacktestConfig, argparse.Namespace]:
     ns = p.parse_args()
     d = vars(ns)
 
-    evo_cfg = EvolutionConfig(**{k: v for k, v in d.items()
-                                 if k in EvolutionConfig.__annotations__})
-    bt_cfg  = BacktestConfig(**{k: v for k, v in d.items()
-                                 if k in BacktestConfig.__annotations__})
+    from dataclasses import fields
+
+    evo_fields = {f.name for f in fields(EvolutionConfig)}
+    bt_fields = {f.name for f in fields(BacktestConfig)}
+
+    evo_cfg = EvolutionConfig(**{k: v for k, v in d.items() if k in evo_fields})
+    bt_cfg = BacktestConfig(**{k: v for k, v in d.items() if k in bt_fields})
 
     return evo_cfg, bt_cfg, ns
 


### PR DESCRIPTION
## Summary
- include inherited dataclass fields when parsing CLI arguments

## Testing
- `python - <<'PY'
import run_pipeline, sys
sys.argv=['run_pipeline.py','1','--data_dir','tests/data/good','--max_lookback_data_option','full_overlap','--top','0','--quiet','--workers','1']
print(run_pipeline.parse_args())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6849c694b3c8832e9aade3ff239576bd