### PR TITLE
Remove duplicate argparse import in CLI utilities

### DIFF
--- a/utils/cli.py
+++ b/utils/cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import argparse
 from dataclasses import fields as dc_fields
-import argparse
 
 
 def add_dataclass_args(


### PR DESCRIPTION
## Summary
- remove redundant argparse import in utils/cli.py

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5fbb32924832e9c1c5241b5b0b8be