### PR TITLE
Handle missing clipboard dependency gracefully

### DIFF
--- a/sc2.py
+++ b/sc2.py
@@ -11,11 +11,12 @@ import sys
 from pathlib import Path
 
 # ---------- optional deps ---------- #
+PYPERCLIP_WARNING: str | None = None
 try:
     import pyperclip  # type: ignore
 except ImportError:
     pyperclip = None
-    print(
+    PYPERCLIP_WARNING = (
         "Note: Clipboard functionality ('pyperclip') is not available. Install it with 'uv add pyperclip'."
     )
 
@@ -207,6 +208,9 @@ def main() -> None:
         "-v", "--verbose", action="store_true", help="print every included file"
     )
     ns = ap.parse_args()
+
+    if PYPERCLIP_WARNING and not ns.write:
+        print(PYPERCLIP_WARNING)
 
     if not ns.tests:
         EXCLUDED_DIRS.add("tests")


### PR DESCRIPTION
## Summary
- Remove import-time print when `pyperclip` is missing
- Warn about missing clipboard support only when needed after argument parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fbcb31a0832eab46220660c5751d